### PR TITLE
Start LiveCode automatically for Taylor series exercise

### DIFF
--- a/book/numerical_methods/taylor-series-exercise.ipynb
+++ b/book/numerical_methods/taylor-series-exercise.ipynb
@@ -93,7 +93,8 @@
    "metadata": {
     "scrolled": true,
     "tags": [
-     "thebe-remove-input-init"
+     "thebe-remove-input-init",
+     "auto-execute-page"
     ]
    },
    "outputs": [],

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ sphinx-tudelft-theme
 sphinx-named-colors
 docutils == 0.17.1
 
---extra-index-url https://gitlab.tudelft.nl/api/v4/projects/11239/packages/pypi/simple
-sphinx-thebe ~= 0.9.9
+git+https://github.com/TeachBooks/Sphinx-Thebe


### PR DESCRIPTION
The equation in the exercise was only showing when the LiveCode button was pressed, which I found confusing. I added a cell tag to start the LiveCode automatically (but did not test if it works locally yet).