### PR TITLE
Fix broken link in banner

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -32,7 +32,7 @@ sphinx:
       use_edit_page_button: true
       use_repository_button: true
       use_issues_button : true
-      announcement: "<p>This book is under construction and should not be regarded as published. The version currently used in education is at <a href='https://mude.citg.tudelft.nl/book/2025' style='color: cyan;'>mude.citg.tudelft.nl/book/2025</a></p>"
+      announcement: "<p>This book is under construction and should not be regarded as published. The version currently used in education is at <a href='https://mude.citg.tudelft.nl/2024/book' style='color: cyan;'>mude.citg.tudelft.nl/2024/book</a></p>"
       launch_buttons:
         thebe: true
     bibtex_default_style: myapastyle


### PR DESCRIPTION
This should also be merged to branch 2025 (if that is still the workflow, first "draft" then "publish"). The link was different in "2025" than in "2025-draft" but equally broken. 