### PR TITLE
Add overview section to book with weekly dropdowns

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -10,16 +10,11 @@ parts:
     numbered: 2
     chapters: 
     - file: modelling/overview
-      title: Modelling Concepts
       sections:
       - file: modelling/classification
-        title: Classification
       - file: modelling/decisions
-        title: Decisions
       - file: modelling/validate_verify
-        title: Calibration, Validation & Verification
       - file: modelling/gof
-        title: Goodness of Fit
     - file: propagation_uncertainty/overview
       sections:
       - file: propagation_uncertainty/00a_CovCorr.md

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -2,6 +2,10 @@ format: jb-book
 root: intro
 
 parts:
+  - caption: Introduction
+    numbered: false
+    chapters:
+    - file: overview
   - caption: Q1 Topics
     numbered: 2
     chapters: 

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -18,7 +18,7 @@ parts:
     - file: propagation_uncertainty/overview
       sections:
       - file: propagation_uncertainty/00a_CovCorr.md
-      - file: propagation_uncertainty/00b_MultivariateNormal
+      - file: propagation_  uncertainty/00b_MultivariateNormal
       - file: propagation_uncertainty/uncertainty
       - file: propagation_uncertainty/01_ErrorPropagation.md
       - file: propagation_uncertainty/02_LinearPropagation.md
@@ -49,7 +49,6 @@ parts:
       - file: observation_theory/99_NotationFormulas
     
     - file: numerical_methods/overview
-      title: Numerical Modelling
       sections:
       - file: numerical_methods/1-revision-of-concepts.ipynb
       - file: numerical_methods/2-derivative.ipynb
@@ -64,12 +63,10 @@ parts:
       - file: numerical_methods/9-starting_with_PDEs.ipynb
 
     - file: probability/Reminder_intro
-      title: Univariate Continuous Distributions
       sections:
       - file: probability/PDF_CDF
       - file: probability/empirical
       - file: probability/Param_distr.md
-        title: Parametric distributions
         sections: 
         - file: probability/Gaussian.md
         - file: probability/other_distr.md
@@ -79,7 +76,6 @@ parts:
         - file: probability/Lognormal.md
         - file: probability/summary.md
       - file: probability/fitting.md
-        title: Fitting parametric distributions
         sections: 
         - file: probability/moments.md
         - file: probability/MLE_1.ipynb
@@ -87,18 +83,12 @@ parts:
       - file: probability/Loc-scale.ipynb
 
     - file: multivariate/overview
-      title: Multivariate Distributions
       sections:
       - file: multivariate/events
-        title: Discrete Events
       - file: multivariate/variables
-        title: Continuous Variables
       - file: multivariate/gaussian
-        title: Multivariate Gaussian
       - file: multivariate/nongaussian
-        title: Non-Gaussian Distributions
       - file: multivariate/design
-        title: Practical Applications
         sections:
         - file: multivariate/design/one-random-variable
         - file: multivariate/design/two-random-variables
@@ -114,19 +104,13 @@ parts:
     numbered: 2
     chapters:
     - file: fvm/intro.md
-      title: Finite Volume Method
       sections:
       - file: fvm/getting_started_new.ipynb
-        title: Getting Started
       - file: fvm/fvm.ipynb
-        title: Finite Volume Method
       - file: fvm/advection_1.ipynb
-        title: Advection and Diffusion
       - file: fvm/unstructured_meshes.ipynb
-        title: Unstructured Meshes
 
     - file: fem/intro.md
-      title: Finite Element Method
       sections:
       - file: fem/strong.md
       - file: fem/weak.md
@@ -138,52 +122,34 @@ parts:
       - file: fem/isoparametric_mapping.md
 
     - file: signal/intro.md
-      title: Signal Processing
       sections:
       - file: signal/fourier_real
-        title: Fourier Series
         sections:
         - file: signal/fourier_nb
-          title: Square Wave Example
       - file: signal/fourier_complex
-        title: Complex Fourier Series
       - file: signal/fourier_transf
-        title: Fourier Transform
       - file: signal/sampling
-        title: Sampling
       - file: signal/dft
-        title: Discrete Fourier Transform
       - file: signal/spectral_est
-        title: Spectral Estimation
       - file: signal/videos
-        title: Supplementary Videos
 
     - file: time_series/intro.md
-      title: Time Series Analysis
       sections:
       - file: time_series/components.md
-        title: "Time Series components"
         sections:
         - file: time_series/exercise1.ipynb
       - file: time_series/noise.ipynb
-        title: "Noise and stochastic model"
       - file: time_series/modelling
-        title: "Time Series modelling and estimation"
         sections:
         - file: time_series/fit_BLUE.ipynb
       - file: time_series/stationarity
-        title: "Stationarity"
       - file: time_series/acf
-        title: "Autocovariance function (ACF)"
       - file: time_series/ar.ipynb
-        title: "AutoRegressive (AR) process"
         sections:
         - file: time_series/ar_exercise.ipynb
       - file: time_series/forecasting
-        title: "Time Series forecasting"
   
     - file: optimization/overview
-      title: Optimization
       sections:
       - file: optimization/origins
       - file: optimization/general
@@ -202,16 +168,13 @@ parts:
       - file: optimization/some_constraints
       - file: optimization/genetic_algorithm
       - file: optimization/airlines.ipynb
-        title: Airline Exercise (Optional)
         # START REMOVE-FROM-PUBLISH
       - file: optimization/performance
-        title: Performance Considerations in LP (Optional)
         sections:
         - file: optimization/airlines_performance.ipynb
         - file: optimization/performance_generic_LP.ipynb
         # END REMOVE-FROM-PUBLISH
       - file: optimization/project
-        title: Road Network Design Problem (GA)
         sections:
         - file: optimization/Project_MILP.ipynb
         - file: optimization/Project_GA.ipynb
@@ -227,42 +190,26 @@ parts:
       - file: ml/review
 
     - file: eva/intro.md
-      title: Extreme Value Analysis
       sections:
       - file: eva/extreme.md
-        title: Concept of Extreme
         sections:
         - file: eva/RT.md
-          title: Return period
         - file: eva/sampling.md
-          title: Sampling extremes
       - file: eva/BM_GEV.md
-        title: Block Maxima & GEV
         sections:
         - file: eva/BM.md
-          title: Block Maxima
         - file: eva/Asymptotic.md
-          title: Asymptotic theorem
         - file: eva/GEV.md
-          title: GEV distribution
         - file: eva/RP_Binomial.md
-          title: RT & Design Life
       - file: eva/POT_GPD.md
-        title: POT & GPD
         sections:
         - file: eva/POT.md
-          title: Peak Over Threshold
         - file: eva/Poisson.md
         - file: eva/Threshold.md
-          title: Parameters selection
         - file: eva/GPD.md
-          title: Intro to GPD
         - file: eva/GPD2.md
-          title: Practicalities for GPD
         - file: eva/RP_Poisson.md
-          title: Revisiting RT
       - file: eva/extra.md
-        title: Supplementary Material
         sections:
         - file: eva/Bernoulli.md
         - file: eva/videos.md
@@ -278,7 +225,6 @@ parts:
       #   - file: pd/prob-design/example-river-system.md
       sections:
       - file: pd/risk-analysis/overview.md
-        title: Risk Introduction
         sections:
         - file: pd/risk-analysis/definition.md
         - file: pd/risk-analysis/steps.md

--- a/book/eva/extreme.md
+++ b/book/eva/extreme.md
@@ -1,5 +1,5 @@
 
-# Extremes
+# Concept of Extremes
 
 If you hear the word "**extreme**", the first thing that may come to your mind are extreme sports or natural disasters, such as a hurricane or a typhon. That gives us an intuition of what is an extreme observation in probability theory. Let's see it in further detail with a dummy example.
 

--- a/book/fvm/advection_1.ipynb
+++ b/book/fvm/advection_1.ipynb
@@ -4,7 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "# Advection - Linear Propagation\n",
+        "# Advection\n",
         "\n",
         "In the first chapter, it was shown that for incompressible flow, constant diffusion coefficient ($D$) and accounting for mass conservation, the equation of transport can be expressed as:\n",
         "\n",

--- a/book/modelling/classification.md
+++ b/book/modelling/classification.md
@@ -1,4 +1,4 @@
-# Introduction to modelling
+# Model classification
 
 ## What is a Model?
 

--- a/book/modelling/decisions.md
+++ b/book/modelling/decisions.md
@@ -1,4 +1,4 @@
-# Model Decisions
+# Model decisions
 
 In this section, we are going to focus on the decisions we make when setting up a model. We will start seeing models as part of the creative and decision making process!
 

--- a/book/modelling/overview.md
+++ b/book/modelling/overview.md
@@ -1,6 +1,6 @@
-# Modelling
+# Modelling concepts
 
-In this section, you will be introduced to the basic concepts related to modelling. The chapter is split into four sections, with the aim of each to enable you to discuss and answer the following questions, respectively:
+In this chapter, you will be introduced to the basic concepts related to modelling. The chapter is split into four sections, with the aim of each to enable you to discuss and answer the following questions, respectively:
 - What is a model and which types of models can be built?
 - How do I choose the appropriate model?
 - How do I know that a model is accurate?

--- a/book/modelling/validate_verify.md
+++ b/book/modelling/validate_verify.md
@@ -1,4 +1,4 @@
-# Model Verification, Calibration and Validation
+# Verification, Calibration and Validation
 
 ```{note}
 *All models are wrong, but some are useful.*

--- a/book/multivariate/design.md
+++ b/book/multivariate/design.md
@@ -1,5 +1,5 @@
 (multivar_design)=
-# Practical Applications: Designing with Probability
+# Designing with Probability
 
 % MMMMM This material is not in R&R book
 

--- a/book/multivariate/events.md
+++ b/book/multivariate/events.md
@@ -1,5 +1,7 @@
 (multivariate_events)=
-# Events: Fundamentally Refreshing
+# Discrete events
+
+% Old title: Fundamentally Refreshing
 
 Before going further into _continuous multivariate distributions,_ we will start with a reminder of some basic concepts you have seen previously: independence and conditional probability, illustrated by considering the probability of _events._
 

--- a/book/multivariate/gaussian.md
+++ b/book/multivariate/gaussian.md
@@ -1,5 +1,5 @@
 
-# Multivariate Gaussian distribution
+# Gaussian distribution
 
 One of the simplest approaches we have to define a multivariate distribution, $F(x, y)$, is through the multivariate Gaussian distribution. This model assumes that both the marginals and the dependence are Gaussian. As you saw in previous chapters, the Gaussian distribution is not always the best model so the applicability of the multivariate Gaussian is limited. However, it is a convenient model since it can be manipulated analytically and we can use it as a first approach to model the dependence. 
 

--- a/book/multivariate/nongaussian.md
+++ b/book/multivariate/nongaussian.md
@@ -1,5 +1,5 @@
 
-# Non-Gaussian Multivariate Distributions
+# Non-Gaussian Distributions
 
 The multivariate Gaussian distribution $\Phi_X(x)$ is a simple, effective and widely used approach for capturing dependence in multivariate situations. However, for continuous random variables, it has limitations due to its inability to capture:
 

--- a/book/multivariate/variables.md
+++ b/book/multivariate/variables.md
@@ -1,5 +1,5 @@
 (multivariate_variables)=
-# Multivariate Continuous Random Variables
+# Continuous Random Variables
 
 This page covers fundamental concepts for _continuous random variables._ As we are interested in considering more than one variable simultaneously, the term _multivariate_ is used. We will start by translating the concepts covered on the previous page from _discrete events_, allowing us to arrive at a clear understanding of the concept of probabilistic _dependence_ for multivariate continuous random variables.
 

--- a/book/overview.md
+++ b/book/overview.md
@@ -1,0 +1,150 @@
+# Overview
+
+:::::{dropdown} Week 1.1
+
+### Modelling Concepts
+
+- Book theory
+  - [](./modelling/classification)
+  - [](./modelling/decisions)
+  - [](./modelling/validate_verify)
+  - [](./modelling/gof)
+<!---
+- Lecture slides
+- [Workshop](https://tudelft-mude.github.io/workbook-2025/assignments/WS1.1/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA1.1/README.html)
+- Fundamental concepts
+  - 
+--->
+
+### Programming: Getting started!
+
+- Book theory
+  - [](./programming/week_1_1/environments)
+- Fundamental programming concepts
+  - [Files and Folders book](https://teachbooks.io/files-and-folders/EN/)
+<!---
+  - [Python basics](https://teachbooks.io/learn-python/restructure-book/basics/intro.html)
+- [Programming assignment](https://tudelft-mude.github.io/workbook-2025/assignments/PA1.1/README.html)
+--->
+:::::
+
+:::::{dropdown} Week 1.2
+
+### Numerical Modelling 1
+
+### Programming: reporting
+
+:::::
+
+:::::{dropdown} Week 1.3
+
+### Numerical Modelling 2
+
+### Programming: collaborating
+
+::::
+
+:::::{dropdown} Week 1.4
+
+### Univariate Distributions
+
+### Programming: git
+
+:::::
+
+:::::{dropdown} Week 1.5
+
+### Multivariate Distributions
+
+### Programming: versioning
+
+:::::
+
+:::::{dropdown} Week 1.6
+
+### Uncertainty Propagation
+
+### Programming: prompting
+
+:::::
+
+:::::{dropdown} Week 1.7
+
+### Observation Theory 1
+
+### Programming: ...
+
+:::::
+
+:::::{dropdown} Week 1.8
+
+### Observation Theory 2
+
+### Programming: ...
+
+:::::
+
+:::::{dropdown} Week 2.1
+
+### PDE's, FDM, FVM
+
+### Programming: object-oriented programming
+
+:::::
+
+:::::{dropdown} Week 2.2
+
+### FEM
+
+### Programming: sparse matrices
+
+:::::
+
+:::::{dropdown} Week 2.3
+
+### Signal processing
+
+### Programming: errors
+
+:::::
+
+:::::{dropdown} Week 2.4
+
+### Time series analysis
+
+### Programming: tests
+
+:::::
+
+:::::{dropdown} Week 2.5
+
+### Optimization
+
+### Programming: packages and modules
+
+:::::
+
+:::::{dropdown} Week 2.6
+
+### Machine learning
+
+### Programming: ...
+
+:::::
+
+:::::{dropdown} Week 2.7
+
+### Extreme Value Analysis
+
+### Programming: ...
+
+:::::
+
+:::::{dropdown} Week 2.8
+
+### Risk Analysis
+
+### Programming: ...
+
+:::::

--- a/book/overview.md
+++ b/book/overview.md
@@ -2,7 +2,7 @@
 
 :::::{dropdown} Week 1.1
 
-### Modelling Concepts
+## Modelling Concepts
 
 - Book theory
   - [](./modelling/classification)
@@ -17,7 +17,7 @@
   - 
 --->
 
-### Programming: Getting started!
+## Programming: Getting started!
 
 - Book theory
   - [](./programming/week_1_1/environments)
@@ -29,122 +29,125 @@
 --->
 :::::
 
+<!---
 :::::{dropdown} Week 1.2
 
-### Numerical Modelling 1
+## Numerical Modelling 1
 
-### Programming: reporting
+## Programming: reporting
 
 :::::
 
 :::::{dropdown} Week 1.3
 
-### Numerical Modelling 2
+## Numerical Modelling 2
 
-### Programming: collaborating
+## Programming: collaborating
 
 ::::
 
 :::::{dropdown} Week 1.4
 
-### Univariate Distributions
+## Univariate Distributions
 
-### Programming: git
+## Programming: git
 
 :::::
 
 :::::{dropdown} Week 1.5
 
-### Multivariate Distributions
+## Multivariate Distributions
 
-### Programming: versioning
+## Programming: versioning
 
 :::::
 
 :::::{dropdown} Week 1.6
 
-### Uncertainty Propagation
+## Uncertainty Propagation
 
-### Programming: prompting
+## Programming: prompting
 
 :::::
 
 :::::{dropdown} Week 1.7
 
-### Observation Theory 1
+## Observation Theory 1
 
-### Programming: ...
+## Programming: ...
 
 :::::
 
 :::::{dropdown} Week 1.8
 
-### Observation Theory 2
+## Observation Theory 2
 
-### Programming: ...
+## Programming: ...
 
 :::::
 
 :::::{dropdown} Week 2.1
 
-### PDE's, FDM, FVM
+## PDE's, FDM, FVM
 
-### Programming: object-oriented programming
+## Programming: object-oriented programming
 
 :::::
 
 :::::{dropdown} Week 2.2
 
-### FEM
+## FEM
 
-### Programming: sparse matrices
+## Programming: sparse matrices
 
 :::::
 
 :::::{dropdown} Week 2.3
 
-### Signal processing
+## Signal processing
 
-### Programming: errors
+## Programming: errors
 
 :::::
 
 :::::{dropdown} Week 2.4
 
-### Time series analysis
+## Time series analysis
 
-### Programming: tests
+## Programming: tests
 
 :::::
 
 :::::{dropdown} Week 2.5
 
-### Optimization
+## Optimization
 
-### Programming: packages and modules
+## Programming: packages and modules
 
 :::::
 
 :::::{dropdown} Week 2.6
 
-### Machine learning
+## Machine learning
 
-### Programming: ...
+## Programming: ...
 
 :::::
 
 :::::{dropdown} Week 2.7
 
-### Extreme Value Analysis
+## Extreme Value Analysis
 
-### Programming: ...
+## Programming: ...
 
 :::::
 
 :::::{dropdown} Week 2.8
 
-### Risk Analysis
+## Risk Analysis
 
-### Programming: ...
+## Programming: ...
 
 :::::
+
+--->

--- a/book/overview.md
+++ b/book/overview.md
@@ -9,13 +9,12 @@
   - [](./modelling/decisions)
   - [](./modelling/validate_verify)
   - [](./modelling/gof)
-<!---
 - Lecture slides
 - [Workshop](https://tudelft-mude.github.io/workbook-2025/assignments/WS1.1/README.html)
 - [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA1.1/README.html)
 - Fundamental concepts
-  - 
---->
+  - tbd
+
 
 ## Programming: Getting started!
 
@@ -23,10 +22,8 @@
   - [](./programming/week_1_1/environments)
 - Fundamental programming concepts
   - [Files and Folders book](https://teachbooks.io/files-and-folders/EN/)
-<!---
   - [Python basics](https://teachbooks.io/learn-python/restructure-book/basics/intro.html)
 - [Programming assignment](https://tudelft-mude.github.io/workbook-2025/assignments/PA1.1/README.html)
---->
 :::::
 
 <!---

--- a/book/overview.md
+++ b/book/overview.md
@@ -4,7 +4,7 @@
 
 **Modelling concepts**
 
-- [Book theory](./modelling/overview)
+- [Book chapter](./modelling/overview)
   - [](./modelling/classification)
   - [](./modelling/decisions)
   - [](./modelling/validate_verify)
@@ -17,7 +17,7 @@
 
 **Programming: getting started!**
 
-- [Book theory](./programming/week_1_1.md)
+- [Book chapter](./programming/week_1_1.md)
   - [](./programming/week_1_1/environments)
 - Fundamental programming concepts
   - [Files and Folders book](https://teachbooks.io/files-and-folders/EN/)

--- a/book/overview.md
+++ b/book/overview.md
@@ -1,5 +1,9 @@
 # Overview
 
+This page shows an overview of the book theory, lecture slides, assignments and fundamental concepts per week.
+
+<!---
+
 :::::{dropdown} Week 1.1
 
 **Modelling concepts**
@@ -26,10 +30,21 @@
 
 :::::
 
-<!---
 :::::{dropdown} Week 1.2
 
 ## Numerical Modelling 1
+
+- [Book theory](./numerical_methods/overview)
+  - [](./numerical_methods/1-revision-of-concepts.ipynb)
+  - [](./numerical_methods/1-revision-of-concepts.ipynb)
+  - [](./numerical_methods/2-derivative.ipynb)
+  - [](./numerical_methods/3-fdm-introduction.ipynb)
+  - [](./numerical_methods/4-taylor-series-expansion.ipynb)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS1.2/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA1.2/README.html)
+- Fundamental concepts
+  - tbd
 
 ## Programming: reporting
 
@@ -39,6 +54,18 @@
 
 ## Numerical Modelling 2
 
+- [Book theory](./numerical_methods/overview)
+  - [](./numerical_methods/5-numerical-integration.ipynb)
+  - [](./numerical_methods/6-initial-value-problem-singlestep.ipynb)
+  - [](./numerical_methods/7-multistep_and_multistage_methods.ipynb)
+  - [](./numerical_methods/8-boundary-value-problem.ipynb)
+  - [](./numerical_methods/9-starting_with_PDEs.ipynb)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS1.3/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA1.13/README.html)
+- Fundamental concepts
+  - tbd
+
 ## Programming: collaborating
 
 ::::
@@ -46,6 +73,18 @@
 :::::{dropdown} Week 1.4
 
 ## Univariate Distributions
+
+- [Book theory](./probability/Reminder_intro)
+  - [](./probability/PDF_CDF)
+  - [](./probability/empirical)
+  - [](./probability/Param_distr.md)
+  - [](./probability/fitting.md)
+  - [](./probability/Loc-scale.ipynb)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS1.4/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA1.4/README.html)
+- Fundamental concepts
+  - tbd
 
 ## Programming: git
 
@@ -55,6 +94,18 @@
 
 ## Multivariate Distributions
 
+- [Book theory](./multivariate/overview)
+  - [](./multivariate/events)
+  - [](./multivariate/variables)
+  - [](./multivariate/gaussian)
+  - [](./multivariate/nongaussian)
+  - [](./multivariate/design)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS1.5/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA1.5/README.html)
+- Fundamental concepts
+  - tbd
+
 ## Programming: versioning
 
 :::::
@@ -62,6 +113,18 @@
 :::::{dropdown} Week 1.6
 
 ## Uncertainty Propagation
+
+- [Book theory](./propagation_uncertainty/overview)
+  - [](./propagation_uncertainty/00a_CovCorr.md)
+  - [](./propagation_  uncertainty/00b_MultivariateNormal)
+  - [](./propagation_uncertainty/uncertainty)
+  - [](./propagation_uncertainty/01_ErrorPropagation.md)
+  - [](./propagation_uncertainty/02_LinearPropagation.md)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS1.6/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA1.6/README.html)
+- Fundamental concepts
+  - tbd
 
 ## Programming: prompting
 
@@ -71,6 +134,16 @@
 
 ## Observation Theory 1
 
+- [Book theory](./observation_theory/overview.md)
+  - [](./observation_theory/01_Introduction.md)
+  - [](./observation_theory/02_LeastSquares.md)
+  - [](./observation_theory/03_WeightedLSQ.md)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS1.7/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA1.7/README.html)
+- Fundamental concepts
+  - tbd
+
 ## Programming: ...
 
 :::::
@@ -78,6 +151,20 @@
 :::::{dropdown} Week 1.8
 
 ## Observation Theory 2
+
+- [Book theory](./observation_theory/overview.md)
+  - [](./observation_theory/04_BLUE.md)
+  - [](./observation_theory/05_Precision.md)
+  - [](./observation_theory/06_MLE.md)
+  - [](./observation_theory/07_NLSQ.md)
+  - [](./observation_theory/08_Testing.md)
+  - [](./observation_theory/09_TestingSandM.md)
+  - [](./observation_theory/99_NotationFormulas)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS1.8/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA1.8/README.html)
+- Fundamental concepts
+  - tbd
 
 ## Programming: ...
 
@@ -87,6 +174,17 @@
 
 ## PDE's, FDM, FVM
 
+- [Book theory](./fvm/intro.md)
+  - [](./fvm/getting_started_new.ipynb)
+  - [](./fvm/fvm.ipynb)
+  - [](./fvm/advection_1.ipynb)
+  - [](./fvm/unstructured_meshes.ipynb)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS2.1/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA2.1/README.html)
+- Fundamental concepts
+  - tbd
+
 ## Programming: object-oriented programming
 
 :::::
@@ -94,6 +192,21 @@
 :::::{dropdown} Week 2.2
 
 ## FEM
+
+- [Book theory](./fem/intro.md)
+  - [](./fem/strong.md)
+  - [](./fem/weak.md)
+  - [](./fem/discrete.ipynb)
+  - [](./fem/matrix.ipynb)
+  - [](./fem/shape.md)
+  - [](./fem/numerical_integration.md)
+  - [](./fem/poisson2d.md)
+  - [](./fem/isoparametric_mapping.md)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS2.2/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA2.2/README.html)
+- Fundamental concepts
+  - tbd
 
 ## Programming: sparse matrices
 
@@ -103,6 +216,20 @@
 
 ## Signal processing
 
+- [Book theory](./signal/intro.md)
+  - [](./signal/fourier_real)
+  - [](./signal/fourier_complex)
+  - [](./signal/fourier_transf)
+  - [](./signal/sampling)
+  - [](./signal/dft)
+  - [](./signal/spectral_est)
+  - [](./signal/videos)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS2.3/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA2.3/README.html)
+- Fundamental concepts
+  - tbd
+
 ## Programming: errors
 
 :::::
@@ -110,6 +237,20 @@
 :::::{dropdown} Week 2.4
 
 ## Time series analysis
+
+- [Book theory](./time_series/intro.md)
+  - [](./time_series/components.md)
+  - [](./time_series/noise.ipynb)
+  - [](./time_series/modelling)
+  - [](./time_series/stationarity)
+  - [](./time_series/acf)
+  - [](./time_series/ar.ipynb)
+  - [](./time_series/forecasting)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS2.4/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA2.4/README.html)
+- Fundamental concepts
+  - tbd
 
 ## Programming: tests
 
@@ -119,6 +260,23 @@
 
 ## Optimization
 
+- [Book theory](./optimization/overview)
+  - [](./optimization/origins)
+  - [](./optimization/general)
+  - [](./optimization/taxonomy)
+  - [](./optimization/sand_and_clay)
+  - [](./optimization/augmented_form)
+  - [](./optimization/sand_and_clay_simplex)
+  - [](./optimization/integer_programming)
+  - [](./optimization/some_constraints)
+  - [](./optimization/genetic_algorithm)
+  - [](./optimization/airlines.ipynb)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS2.5/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA2.5/README.html)
+- Fundamental concepts
+  - tbd
+
 ## Programming: packages and modules
 
 :::::
@@ -126,6 +284,19 @@
 :::::{dropdown} Week 2.6
 
 ## Machine learning
+
+- [Book theory](./ml/overview)
+  - [](./ml/knn_interactive)
+  - [](./ml/decision_theory_interactive)
+  - [](./ml/linear_models_interactive)
+  - [](./ml/ridge_sgd_interactive)
+  - [](./ml/nn_interactive)
+  - [](./ml/review)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS2.6/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA2.6/README.html)
+- Fundamental concepts
+  - tbd
 
 ## Programming: ...
 
@@ -135,6 +306,17 @@
 
 ## Extreme Value Analysis
 
+- [Book theory](./eva/intro.md)
+  - [](./eva/extreme.md)
+  - [](./eva/BM_GEV.md)
+  - [](./eva/POT_GPD.md)
+  - [](./eva/extra.md)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS2.7/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA2.7/README.html)
+- Fundamental concepts
+  - tbd
+
 ## Programming: ...
 
 :::::
@@ -142,6 +324,16 @@
 :::::{dropdown} Week 2.8
 
 ## Risk Analysis
+
+- [Book theory](./pd/intro.md)
+  - [](./pd/risk-analysis/overview.md)
+  - [](./pd/risk-evaluation/overview.md)
+  - [](./pd/exercises/overview.md)
+- Lecture slides
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS2.8/README.html)
+- [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA2.8/README.html)
+- Fundamental concepts
+  - tbd
 
 ## Programming: ...
 

--- a/book/overview.md
+++ b/book/overview.md
@@ -2,28 +2,28 @@
 
 :::::{dropdown} Week 1.1
 
-## Modelling Concepts
+**Modelling concepts**
 
-- Book theory
+- [Book theory](./modelling/overview)
   - [](./modelling/classification)
   - [](./modelling/decisions)
   - [](./modelling/validate_verify)
   - [](./modelling/gof)
 - Lecture slides
-- [Workshop](https://tudelft-mude.github.io/workbook-2025/assignments/WS1.1/README.html)
+- [Workshop assignment](https://tudelft-mude.github.io/workbook-2025/assignments/WS1.1/README.html)
 - [Group assignment](https://tudelft-mude.github.io/workbook-2025/assignments/GA1.1/README.html)
 - Fundamental concepts
   - tbd
 
+**Programming: getting started!**
 
-## Programming: Getting started!
-
-- Book theory
+- [Book theory](./programming/week_1_1.md)
   - [](./programming/week_1_1/environments)
 - Fundamental programming concepts
   - [Files and Folders book](https://teachbooks.io/files-and-folders/EN/)
-  - [Python basics](https://teachbooks.io/learn-python/restructure-book/basics/intro.html)
+  - [Python basics in Learn-Python book](https://teachbooks.io/learn-python/restructure-book/basics/intro.html)
 - [Programming assignment](https://tudelft-mude.github.io/workbook-2025/assignments/PA1.1/README.html)
+
 :::::
 
 <!---

--- a/book/probability/Reminder_intro.md
+++ b/book/probability/Reminder_intro.md
@@ -1,5 +1,5 @@
 (cont_dist)=
-# Continuous Distributions
+# Univariate Continuous Distributions
 
 Civil engineering and Geosciences involve working with nature and that comes with associated [uncertainties](https://mude.citg.tudelft.nl/book/propagation_uncertainty/uncertainty.html). Natural phenomena have an intrinsic aleatoric uncertainty that we need to model. Moreover, we don't always have the resources to neglect the epistemic uncertainty; we typically need to make decisions in scenarios of data scarcity. 
 

--- a/book/signal/dft.md
+++ b/book/signal/dft.md
@@ -1,5 +1,5 @@
 (dft)=
-# Discrete Fourier Transform (DFT)
+# Discrete Fourier Transform
 
 ## Discrete time Fourier Transform (DTFT)
 

--- a/book/signal/fourier_nb.ipynb
+++ b/book/signal/fourier_nb.ipynb
@@ -5,7 +5,7 @@
    "id": "1bfcca26",
    "metadata": {},
    "source": [
-    "# Create a Square Wave with Fourier Series"
+    "# Square wave example"
    ]
   },
   {

--- a/book/time_series/acf.md
+++ b/book/time_series/acf.md
@@ -1,5 +1,5 @@
 (ACF)=
-# Autocovariance function (ACF)
+# Autocovariance function
 
 Before we can look into the modelling of a stochastic process using an Autoregressive (AR) model, we first need to introduce the autocovariance function (ACF) for a stationary time series, and describe the relationship between ACF and a power spectral density (PSD).
 

--- a/book/time_series/ar.ipynb
+++ b/book/time_series/ar.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "(AR)=\n",
-    "# AR process\n",
+    "# Autoregressive process\n",
     "The code on this page can be used interactively: click {fa}`rocket` --> {guilabel}`Live Code` in the top right corner, then wait until the message {guilabel}`Python interaction ready!` appears.\n",
     "\n",
     "The main goal is to introduce the AutoRegressive (AR) model to describe a **stationary stochastic process**. Hence the AR model can be applied on time series where e.g. trend and seasonality are not present / removed, and only noise remains, or after applying other methods [to obtain a stationary time series](stationarize).\n",


### PR DESCRIPTION
Introduced a new 'Introduction' part in the table of contents and added an 'overview.md' file. The overview provides a week-by-week dropdown structure summarizing modelling and programming topics for each week: https://tudelft-mude.github.io/book/overview-page/overview.html