### PR TITLE
2024 version: make open and archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the source code for the MUDE Online Textbook from the 2
 
 This book is constantly in development, so feel free to contribute! You can do so directly by forking this repository and creating a pull request. If you have access to this repository, create a branch and pull request to contribute directly.
 
-The released book can be found on on https://tudelft-mude.github.io/book/. This page shows the built book of the default branch (it will be the upcoming academic year). All branches will also be visible as seen in the action's summaries: https://github.com/TUDelft-MUDE/book/actions
+The released book can be found on on https://mude.citg.tudelft.nl/book/. This page shows the built book of the default branch (it will be the upcoming academic year). All branches will also be visible as seen in the action's summaries: https://github.com/TUDelft-MUDE/book/actions
 
 Development of the book is focused around its use as an online textbook for students in MUDE, which takes place from September through January each year. During this period improvements are generally released on a weekly basis. Major updates (for example, to the structure or layout of a page/chapter) are reserved for the following academic year, in order to avoid confusing students that actively used the book in class during the Fall. Therefore, to view the most recent "complete" version of this textbook, one should view the previous academic year, in this case, 2024 (this book!). 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Happy book building!
 ## Contact
 If you encounter any issues, report it by clicking the GitHub icon and lightbulb on the top right corner of this page. Or contribute directly by creating a pull request in the [repository](https://github.com/TUDelft-MUDE/book).
 
-If you have questions on the contact, contact the MUDE team at MUDE-CEG@tudelft.nl. If you've technical questions regarding this book, contact the IT-coordinator of MUDE (Tom): T.R.vanWoudenberg@tudelft.nl
+If you have questions on the content, contact the MUDE team at MUDE-CEG@tudelft.nl. If you have technical questions regarding this book, contact the IT-coordinator of MUDE (Tom): T.R.vanWoudenberg@tudelft.nl
 
 ## Additional Information
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the source code for the MUDE Online Textbook from the 2
 
 This book is constantly in development, so feel free to contribute! You can do so directly by forking this repository and creating a pull request. If you have access to this repository, create a branch and pull request to contribute directly.
 
-The released book can be found on on https://mude.citg.tudelft.nl/book/. This page shows the built book of the default branch (it will be the upcoming academic year). All branches will also be visible as seen in the action's summaries: https://github.com/TUDelft-MUDE/book/actions
+The released book can be found on on https://mude.citg.tudelft.nl/book/. This page shows the built book of the default branch, which is the current or upcoming academic year. All branches will also be visible as seen in the action's summaries: https://github.com/TUDelft-MUDE/book/actions
 
 Development of the book is focused around its use as an online textbook for students in MUDE, which takes place from September through January each year. During this period improvements are generally released on a weekly basis. Major updates (for example, to the structure or layout of a page/chapter) are reserved for the following academic year, in order to avoid confusing students that actively used the book in class during the Fall. Therefore, to view the most recent "complete" version of this textbook, one should view the previous academic year, in this case, 2024 (this book!). 
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,28 @@
 # The MUDE Book
 
-This book will continue to develop, so feel free to contribute https://github.com/TUDelft-MUDE/book! You can do so directly by forking this repository and creating a pull request. If you've access to this repository, create a branch and pull request to contribute directly.
+This repository contains the source code for the MUDE Online Textbook from the 2024-25 academic year. It is the first version released with a CC BY license.  MUDE stands for Modelling, Uncertainty and Data for Engineers, a required module in the MSc programs from the faculty of Civil Engineering and Geosciences at Delft University of Technology in the Netherlands.
 
-The released book can be found on on https://tudelft-mude.github.io/book/. This page shows the built book of the `2025` branch. All branches will also be visible as seen in the action's summaries: https://github.com/TUDelft-MUDE/book/actions
+This book is constantly in development, so feel free to contribute! You can do so directly by forking this repository and creating a pull request. If you have access to this repository, create a branch and pull request to contribute directly.
 
-Some parts of this book are taken from other sources in the form of submodules (linked in the folder [book/external](book/external)). To contribute to those pages, contribute to the source repository directly with a fork and merge/pull request. If you intent to clone this book including its submodules, clone using: `git clone --recurse-submodules git@github.com:TeachBooks/manual.git`
+The released book can be found on on https://tudelft-mude.github.io/book/. This page shows the built book of the default branch (it will be the upcoming academic year). All branches will also be visible as seen in the action's summaries: https://github.com/TUDelft-MUDE/book/actions
+
+Development of the book is focused around its use as an online textbook for students in MUDE, which takes place from September through January each year. During this period improvements are generally released on a weekly basis. Major updates (for example, to the structure or layout of a page/chapter) are reserved for the following academic year, in order to avoid confusing students that actively used the book in class during the Fall. Therefore, to view the most recent "complete" version of this textbook, one should view the previous academic year, in this case, 2024 (this book!). 
+
+Some parts of this book are taken directly from other git repositories (either as submodules or external resources). To contribute to those pages, contribute to the source repository directly with a fork and merge/pull request. If you intend to clone this book including its submodules, clone using: `git clone --recurse-submodules git@github.com:TeachBooks/manual.git`
+
+Additional information about the book (especially for MUDE teachers) can be found at the MUDE Teacher site: [tudelft-mude.github.io/teacher/book](https://tudelft-mude.github.io/teacher/book).
 
 Happy book building!
-
-There are several directories:
-
-- `book/`: primary source files for the book
-- `code/`: auxiliary scripts for generating figures, etc. These are executed via eval-rst blocks, but the functionality is disabled for now.
-- `unused/`: files that were removed from the book. Might be better to hide these in a branch unused/pd/
 
 ## Contact
 If you encounter any issues, report it by clicking the GitHub icon and lightbulb on the top right corner of this page. Or contribute directly by creating a pull request in the [repository](https://github.com/TUDelft-MUDE/book).
 
-If you have questions on the contact, contact the MUDE team at MUDE-CEG@tudelft.nl. If you've technical questions regarding this book, contact the IT-coordinator of MUDE: T.R.vanWoudenberg@tudelft.nl
+If you have questions on the contact, contact the MUDE team at MUDE-CEG@tudelft.nl. If you've technical questions regarding this book, contact the IT-coordinator of MUDE (Tom): T.R.vanWoudenberg@tudelft.nl
+
+## Additional Information
+
+There are several directories that were partially used in 2023-24 but are no longer used (they will be removed in a future PR):
+
+- `book/`: primary source files for the book
+- `code/`: auxiliary scripts for generating figures, etc. These are executed via eval-rst blocks, but the functionality is disabled for now.
+- `unused/`: files that were removed from the book. Might be better to hide these in a branch unused/pd/

--- a/book/_bibliography/references.bib
+++ b/book/_bibliography/references.bib
@@ -478,3 +478,17 @@ M. Tignor, and T. Waterfield (eds.)]. Accessed 2024 at {{https://www.researchgat
 	year = {2024},
 	note = {[Accessed 12-2024]},
 }
+
+@misc{adjustment_thoery,
+  title={Adjustment thoery: an introduction},
+  author={Teunissen, Peter J.G.},
+  url={https://doi.org/10.59490/tb.95},
+	year = {2024},
+}
+
+@misc{testing_thoery,
+  title={Testing thoery: an introduction},
+  author={Teunissen, Peter J.G.},
+  url={https://doi.org/10.59490/tb.96},
+	year = {2024},
+}

--- a/book/_bibliography/references.bib
+++ b/book/_bibliography/references.bib
@@ -479,7 +479,7 @@ M. Tignor, and T. Waterfield (eds.)]. Accessed 2024 at {{https://www.researchgat
 	note = {[Accessed 12-2024]},
 }
 
-@misc{adjustment_thoery,
+@misc{adjustment_theory,
   title={Adjustment thoery: an introduction},
   author={Teunissen, Peter J.G.},
   url={https://doi.org/10.59490/tb.95},

--- a/book/_bibliography/references.bib
+++ b/book/_bibliography/references.bib
@@ -462,3 +462,19 @@ M. Tignor, and T. Waterfield (eds.)]. Accessed 2024 at {{https://www.researchgat
   publisher={TU Delft Open},
   url={https://doi.org/10.59490/tb.89},
 }
+
+@misc{learn-programming,
+  title={Learn Programming for Engineers},
+  author={Lanzafame, Robert and van Woudenberg, Tom},
+  year={2024},
+  note={[Accessed 12-2024]},
+  url={https://teachbooks.io/learn-programming/credits.html},
+}
+
+@misc{learn-Python,
+  title={Python for Engineers},
+  author={Lanzafame, R and Verhagen, S. and Mendoza Lugo, M. and Farahat, A.},
+  url={https://teachbooks.io/learn-python},
+	year = {2024},
+	note = {[Accessed 12-2024]},
+}

--- a/book/_bibliography/references.bib
+++ b/book/_bibliography/references.bib
@@ -486,7 +486,7 @@ M. Tignor, and T. Waterfield (eds.)]. Accessed 2024 at {{https://www.researchgat
 	year = {2024},
 }
 
-@misc{testing_thoery,
+@misc{testing_theory,
   title={Testing thoery: an introduction},
   author={Teunissen, Peter J.G.},
   url={https://doi.org/10.59490/tb.96},

--- a/book/_bibliography/references.bib
+++ b/book/_bibliography/references.bib
@@ -427,3 +427,38 @@ M. Tignor, and T. Waterfield (eds.)]. Accessed 2024 at {{https://www.researchgat
   url={https://www.cmar.csiro.au/sealevel/sl_hist_last_decades.html},
 	note = {[Accessed 10-2024]},
 }
+
+@misc{lanzafame2024,
+  title={Risk and Reliability for Engineers},
+  author={Lanzafame, Robert},
+  year={2024},
+  publisher={TU Delft Open},
+  url={https://doi.org/10.59490/tb.89},
+}
+
+@misc{lanzafame2024-pd,
+  title={Probabilistic Design},
+  author={Lanzafame, Robert},
+  year={2024},
+  note={In Robert Lanzafame (Ed.), Risk and Reliability for Engineers. [Accessed 12-2024]},
+  publisher={TU Delft Open},
+  url={https://doi.org/10.59490/tb.89},
+}
+@misc{lanzafame2024-risk,
+  title={Risk Analysis},
+  author={Jonkman, Bas and Lanzafame, Robert},
+  year={2024},
+  note={In Robert Lanzafame (Ed.), Risk and Reliability for Engineers. [Accessed 12-2024]},
+  publisher={TU Delft Open},
+  url={https://doi.org/10.59490/tb.89},
+}
+
+
+@misc{lanzafame2024-risk-eval,
+  title={Risk Evaluation},
+  author={Jonkman, Bas},
+  year={2024},
+  note={In Robert Lanzafame (Ed.), Risk and Reliability for Engineers. [Accessed 12-2024]},
+  publisher={TU Delft Open},
+  url={https://doi.org/10.59490/tb.89},
+}

--- a/book/_bibliography/references.bib
+++ b/book/_bibliography/references.bib
@@ -411,3 +411,19 @@ author = {Sitar, N. and Cawlfield, J. D. and Der Kiureghian, A.},
 	year = {},
 	note = {[Accessed 24-03-2025]},
 }
+
+@misc{ipcc2018,
+  title={Global Warming of 1.5°C. An IPCC Special Report on the impacts of global warming of 1.5°C above pre-industrial levels and related global greenhouse gas emission pathways, in the context of strengthening the global response to the threat of climate change, sustainable development, and efforts to eradicate poverty},
+  author={{IPCC}},
+	year = {2018},
+	note = {[Masson-Delmotte, V., P. Zhai, H.-O. Pörtner, D. Roberts, J. Skea, P.R. Shukla,
+A. Pirani, W. Moufouma-Okia, C. Péan, R. Pidcock, S. Connors, J.B.R. Matthews, Y. Chen, X. Zhou, M.I. Gomis, E. Lonnoy, T. Maycock,
+M. Tignor, and T. Waterfield (eds.)]. Accessed 2024 at {{https://www.researchgate.net/publication/330090901_Sustainable_development_poverty_eradication_and_reducing_inequalities_In_Global_warming_of_15C_An_IPCC_Special_Report}}},
+}
+
+@misc{csiro,
+  title={Page "Historical sea level changes; Last decades" of website "Sea Level Rise - Understanding the past - improving projections for the future"},
+  author={{CSIRO}},
+  url={https://www.cmar.csiro.au/sealevel/sl_hist_last_decades.html},
+	note = {[Accessed 10-2024]},
+}

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -53,3 +53,6 @@ sphinx:
 
 bibtex_bibfiles:
   - _bibliography/references.bib
+
+teachbooks:
+  attribution_color: attributiongrey

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -50,6 +50,7 @@ sphinx:
     - sphinx_image_inverter
     - sphinx_tudelft_theme
     - sphinx_named_colors
+    - sphinx_iframes
 
 bibtex_bibfiles:
   - _bibliography/references.bib

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -32,7 +32,7 @@ sphinx:
       use_edit_page_button: true
       use_repository_button: true
       use_issues_button : true
-      announcement: "<p>This book is under construction and should not be regarded as published. The version currently used in education is at <a href='https://mude.citg.tudelft.nl/book/2025' style='color: cyan;'>mude.citg.tudelft.nl/book/2025</a></p>"
+      announcement: "<p>This book is from the 2024-25 academic year. The version currently used in education is at <a href='https://mude.citg.tudelft.nl/book' style='color: cyan;'>mude.citg.tudelft.nl/book/2025</a></p>"
       launch_buttons:
         thebe: true
     bibtex_default_style: myapastyle

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -22,7 +22,7 @@ sphinx:
     thebe_config:
       use_thebe_lite: true
       exclude_patterns: []
-      exclude_patterns: ["**/*.JPG", "**/*.PNG", "**/*.bib", "**/*.cpg", "**/*.csv", "**/*.dbf", "**/*.geojson", "**/*.gif", "**/*.html", "**/*.ico", "**/*.ipynb", "**/*.jl", "**/*.jpeg", "**/*.jpg", "**/*.json", "**/*.md", "**/*.npy", "**/*.pdf", "**/*.png", "**/*.prj", "**/*.py", "**/*.sbn", "**/*.sbx", "**/*.shp", "**/*.shx", "**/*.svg", "**/*.tif", "**/*.tiff", "**/*.txt", "**/*.webp", "**/*.whl", "**/*.xlsx", "**/*.xml", "**/*.yml", "**/*.zip"]
+      exclude_patterns: ["**/*.JPG", "**/*.PNG", "**/*.bib", "**/*.cpg", "**/*.csv", "**/*.dbf", "**/*.geojson", "**/*.gif", "**/*.html", "**/*.ico", "**/*.ipynb", "**/*.jl", "**/*.jpeg", "**/*.jpg", "**/*.json", "**/*.md", "**/*.npy", "**/*.pdf", "**/*.png", "**/*.prj", "**/*.sbn", "**/*.sbx", "**/*.shp", "**/*.shx", "**/*.svg", "**/*.tif", "**/*.tiff", "**/*.txt", "**/*.webp", "**/*.whl", "**/*.xlsx", "**/*.xml", "**/*.yml", "**/*.zip"]
     html_theme_options:
       logo:
         text: CEGM1000 Modelling, Uncertainty, and Data for Engineers

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -21,8 +21,6 @@ sphinx:
     - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js
     thebe_config:
       use_thebe_lite: true
-      exclude_patterns: []
-      exclude_patterns: ["**/*.JPG", "**/*.PNG", "**/*.bib", "**/*.cpg", "**/*.csv", "**/*.dbf", "**/*.geojson", "**/*.gif", "**/*.html", "**/*.ico", "**/*.ipynb", "**/*.jl", "**/*.jpeg", "**/*.jpg", "**/*.json", "**/*.md", "**/*.npy", "**/*.pdf", "**/*.png", "**/*.prj", "**/*.sbn", "**/*.sbx", "**/*.shp", "**/*.shx", "**/*.svg", "**/*.tif", "**/*.tiff", "**/*.txt", "**/*.webp", "**/*.whl", "**/*.xlsx", "**/*.xml", "**/*.yml", "**/*.zip"]
       exclude_patterns: ["**/*.JPG", "**/*.PNG", "**/*.bib", "**/*.cpg", "**/*.csv", "**/*.dbf", "**/*.geojson", "**/*.gif", "**/*.html", "**/*.ico", "**/*.ipynb", "**/*.jl", "**/*.jpeg", "**/*.jpg", "**/*.json", "**/*.md", "**/*.npy", "**/*.pdf", "**/*.png", "**/*.prj", "**/*.sbn", "**/*.sbx", "**/*.shp", "**/*.shx", "**/*.svg", "**/*.tif", "**/*.tiff", "**/*.txt", "**/*.webp", "**/*.whl", "**/*.xlsx", "**/*.xml", "**/*.yml", "**/*.zip"]
     html_theme_options:
       logo:

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -23,6 +23,7 @@ sphinx:
       use_thebe_lite: true
       exclude_patterns: []
       exclude_patterns: ["**/*.JPG", "**/*.PNG", "**/*.bib", "**/*.cpg", "**/*.csv", "**/*.dbf", "**/*.geojson", "**/*.gif", "**/*.html", "**/*.ico", "**/*.ipynb", "**/*.jl", "**/*.jpeg", "**/*.jpg", "**/*.json", "**/*.md", "**/*.npy", "**/*.pdf", "**/*.png", "**/*.prj", "**/*.sbn", "**/*.sbx", "**/*.shp", "**/*.shx", "**/*.svg", "**/*.tif", "**/*.tiff", "**/*.txt", "**/*.webp", "**/*.whl", "**/*.xlsx", "**/*.xml", "**/*.yml", "**/*.zip"]
+      exclude_patterns: ["**/*.JPG", "**/*.PNG", "**/*.bib", "**/*.cpg", "**/*.csv", "**/*.dbf", "**/*.geojson", "**/*.gif", "**/*.html", "**/*.ico", "**/*.ipynb", "**/*.jl", "**/*.jpeg", "**/*.jpg", "**/*.json", "**/*.md", "**/*.npy", "**/*.pdf", "**/*.png", "**/*.prj", "**/*.sbn", "**/*.sbx", "**/*.shp", "**/*.shx", "**/*.svg", "**/*.tif", "**/*.tiff", "**/*.txt", "**/*.webp", "**/*.whl", "**/*.xlsx", "**/*.xml", "**/*.yml", "**/*.zip"]
     html_theme_options:
       logo:
         text: CEGM1000 Modelling, Uncertainty, and Data for Engineers

--- a/book/_credits.yml
+++ b/book/_credits.yml
@@ -95,12 +95,24 @@ sources:
     license: CC BY
 
   finite_element_method:
+    title: Finite Elements in Civil Engineering and Geosciences
     author:
+      - Oriol Colomés
+      - Iuri Rocha
       - Frans van der Meer
-      - Oriol?
-      - Martin?
+      - Martin Lesueur
     type: external
     license: CC-BY (but not yet confirmed?)
+    note: 
+      - text: |
+          Frans confirmed that the he and the co-authors want to release the book under CC BY, but have not done so yet. There may be some copyright concerns in the book, but the chapters used in MUDE are fine.
+      - id: fem-source
+        public: true
+        text: |
+          specifically, the chapter "Introduction to finite elements." The book can be accessed at [interactivetextbooks.citg.tudelft.nl/computational-modelling](https://interactivetextbooks.citg.tudelft.nl/computational-modelling) and will soon be published with a CC BY license.
+      - text: |
+          see ./book/fem/readme.md for note about transfer from other repo (along with general transfer instructions for non-credit-specific stuff).
+
 
   optimization:
     title: Optimization

--- a/book/_credits.yml
+++ b/book/_credits.yml
@@ -12,6 +12,8 @@ book:
   version:
     type: semantic-year
     year: 2024
+  note: |
+      There are 4 interactive figures from Max Ramgraber (see resources per chapter). They are located in book/_static/elements/ and can be hard to track down as the figure tags (used for numref) are different than the file names _and_ each file can have more than one name (so that it is easy to list each time that file is used on the credits page). They are (file name/figure name): element_correlation.html/density_scatter, density_scatter_2 and density_scatter_3; element_2D_Gaussian/2D_Gaussian ; element_Gaussian_cdf_moments/pdf_cdf_2; and element_pdf_and_cdf/pdf_cdf.
   
 
 

--- a/book/_credits.yml
+++ b/book/_credits.yml
@@ -157,18 +157,18 @@ sources:
     acknowledgement:
       - name: Max Mulder
         contribution: being a signal processing soul-mate, sparring-partner and TU Delft colleague of the author who co-shaped the material, indirectly, through collaboration since early 2000's.
+      - name: Jelle Knibbe
+        contribution: reviewed, commented and/or modified content of original powerpoint slides.
       - name: João Moura Pereira de Lucas Teixeira
         contribution: created first draft of pages from powerpoint slides.
       - name: Antonio Magherini
         contribution: reviewed, commented and/or modified content
-      - name: Jelle Knibbe
-        contribution: reviewed, commented and/or modified content of original powerpoint slides.
     type: internal
     note:
       - id: other_book
         public: true
         text: |
-          The material in this chapter will be closely related to a future book written by Christiaan Tiberius and Max Mulder (late 2025 target publishing date, via TU Delft Open Publishing).
+          The material in this chapter is closely related to an in-depth book "Engineering signal analysis - from Fourier to filtering" by Christiaan Tiberius and Max Mulder (TU Delft Open Publishing, 2025).
       - text: |
           Note from Christian about the chapter and Max Mulder: I would consider one more person here, namely prof Max Mulder from Aerospace Engineering, as my signal processing soul-mate, sparring-partner and TU Delft colleague...Long time ago we developed and taught a course on this subject together, at Aerospace. We kept in touch (and as you know, we’re actually preparing, together, an Open Textbook on just this subject, hopefully appearing by the end of this year). So, directly his contribution is zero, but indirectly, he co-shaped this material. To say, my way of approaching and teaching signal processing has been determined in a large part by our joint teaching at that time (20 years ago).
       - text: |

--- a/book/_credits.yml
+++ b/book/_credits.yml
@@ -118,23 +118,17 @@ sources:
         contribution: providing a first draft of the chapter structure and contents.
 
   finite_element_method:
-    title: Finite Elements in Civil Engineering and Geosciences
+    title: Finite Element Method
     author:
-      - Oriol Colomés
-      - Iuri Rocha
       - Frans van der Meer
-      - Martin Lesueur
-    type: external
-    license: CC-BY (but not yet confirmed?)
+    type: internal
     note: 
       - text: |
-          Frans confirmed that the he and the co-authors want to release the book under CC BY, but have not done so yet. There may be some copyright concerns in the book, but the chapters used in MUDE are fine.
-      - id: fem-source
-        public: true
-        text: |
-          specifically, the chapter "Introduction to finite elements." The book can be accessed at [interactivetextbooks.citg.tudelft.nl/computational-modelling](https://interactivetextbooks.citg.tudelft.nl/computational-modelling) and will soon be published with a CC BY license.
-      - text: |
-          see ./book/fem/readme.md for note about transfer from other repo (along with general transfer instructions for non-credit-specific stuff).
+          This chapter was originally written by Frans for the MUDE book. It is then included in the book Finite Elements in Civil Engineering and Geosciences by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. There, the chapter is called "Introduction to finite elements" and can be accessed at [interactivetextbooks.citg.tudelft.nl/computational-modelling](https://interactivetextbooks.citg.tudelft.nl/computational-modelling)
+
+          Frans confirmed that the he and the co-authors want to release the book under CC BY, but have not done so yet. There may be some copyright concerns in the book, but the MUDE chapter is fine.
+          
+          Development of this chapter took place in the repo of the other book, and in Fall 2024 the contents were copied back to the MUDE book. See file ./book/fem/readme.md for note about transfer from other repo (along with general transfer instructions for non-credit-specific stuff).
 
 
   optimization:
@@ -225,23 +219,25 @@ sources:
       - Christiaan Tiberius
       - Sandra Verhagen
     acknowledgement:
-      - name: João Moura Pereira de Lucas Teixeira
-        contribution: Created first draft of pages from powerpoint slides
-      - name: Antonio Magherini
-        contribution: reviewed, commented and/or modified content
       - name: Berend Bouvy
-        contribution: created and improved many of the exercises and interactive pages
+        contribution: created a number ofinteractive figures and exercises, as well as provided critical feedback.
+      - name: Antonio Magherini
+        contribution: created the first draft material from powerpoint slides and prepared notebooks as exercises.
     note:
       - text: |
           Alireza Amiri-Simkooei created the main framework of this chapter, which was then revised by Sandra and Christian.
     resource:
-      - name: cover
+      - name_ref: cover
         what: figure
         filename: tsa_cover.png
+        bibtex: ipcc2018
         filepath: https://files.mude.citg.tudelft.nl/
         where: book/2024/time_series/intro.md
-        source_url: https://www.researchgate.net/profile/Peter-Marcotullio/publication/330090901_Sustainable_development_poverty_eradication_and_reducing_inequalities_In_Global_warming_of_15C_An_IPCC_Special_Report/links/6386062b48124c2bc68128da/Sustainable-development-poverty-eradication-and-reducing-inequalities-In-Global-warming-of-15C-An-IPCC-Special-Report.pdf
-      - name: trend
+        source_url: https://www.researchgate.net/publication/330090901_Sustainable_development_poverty_eradication_and_reducing_inequalities_In_Global_warming_of_15C_An_IPCC_Special_Report
+        note: |
+          This figure is used as cover for the chapter. It is unmodified from PDFsource report.
+      - name_ref: trend
+        bibtex: csiro
         what: figure
         filename: trend.png
         filepath: https://files.mude.citg.tudelft.nl/

--- a/book/_credits.yml
+++ b/book/_credits.yml
@@ -40,17 +40,14 @@ sources:
     acknowledgement:
       - name: Robert Lanzafame, Patricia Mares Nasarre, Max Ramgraber
         contribution: reviewed, commented and/or modified content
+      - name: Sophie Keemink, Caspar Jungbacker and Thirza Feenstra
+        contribution: provided feedback and helped develop exercises.
       - name: Antonio Magherini
         contribution: converted the slides and exercises to book format
     resource:
       - name: Max Ramgraber
         what: interactive figure
-        where: https://mude.citg.tudelft.nl/2024/book/_static/elements/element_2D_Gaussian.html
-        license: CC BY 4.0
-        copyright: Delft University of Technology
-      - name: Robert Lanzafame, Patricia Mares Nasarre
-        what: page
-        where: book/propagation_uncertainty/uncertainty.md
+        where: https://mude.citg.tudelft.nl/2024/book/_static/elements/element_correlation.html
         license: CC BY 4.0
         copyright: Delft University of Technology
     type: internal
@@ -59,6 +56,11 @@ sources:
     author:
       - Sandra Verhagen
     type: internal
+    acknowledgement:
+      - name: Sophie Keemink, Caspar Jungbacker and Thirza Feenstra
+        contribution: provided feedback and helped develop exercises.
+      - name: Antonio Magherini
+        contribution: converted the slides and exercises to book format
     note: |
       
 
@@ -88,21 +90,22 @@ sources:
         copyright: Deltares
         note: Original caption from Jaime "Cool numerical model of the Yamuna river. Thanks to Amgad Omer (Deltares).""
 
-  continuous_distributions:
+  distributions:
     author:
       - Patricia Mares Nasarre
-      - ???
-    type: internal
-    note: |
-      Not sure if/when we move it to another book, and how to handle that.
-
-  multivariate_distributions:
-    author:
       - Robert Lanzafame
-      - Patricia Mares Nasarre
     type: internal
     note: |
-      Not sure if/when we move it to another book, and how to handle that.
+      2 pages are from R&R book. Tried to keep things simple and combined univariate and continuous distributions chapter. listed elisa and oswaldo as contributors for now, but expect them to become authors in the future.
+    resource:
+      - name: Max Ramgraber
+        what: interactive figures
+        where:
+          - https://mude.citg.tudelft.nl/2024/book/_static/elements/element_correlation.html
+          - https://mude.citg.tudelft.nl/2024/book/_static/elements/element_Gaussian_cdf_moments.html
+          - https://mude.citg.tudelft.nl/2024/book/_static/elements/element_pdf_and_cdf.html
+        license: CC BY 4.0
+        copyright: Delft University of Technology
 
   finite_volume_method:
     author:
@@ -243,3 +246,17 @@ sources:
         filepath: https://files.mude.citg.tudelft.nl/
         where: book/2024/time_series/components.md
         source_url: https://www.cmar.csiro.au/sealevel/sl_hist_last_decades.html
+
+  extreme_value_analysis:
+    title: Extreme Value Analysis
+    authro: Patricia Mares Nasarre
+    type: internal
+    acknowledgement:
+      - name:
+          - Robert Lanzafame
+          - Oswaldo Morales Napoles
+          - Elisa Ragno
+        contribution: suggestions on the theoretical and didactic framework, as well as critical feedback and review.
+
+  risk_analysis:
+    see credits page. complicated because of the need to cite specific chapters. note that the attributions are also unique in that the chapter attribution mentions that some pages/sections are by Robert and Bas (but leaves credits page to distinguish).

--- a/book/_credits.yml
+++ b/book/_credits.yml
@@ -104,6 +104,7 @@ sources:
       - Anne Poot
       - Joep Storm
       - Leon Riccius
+    type: internal
 
   signal_processing:
     title: Signal Processing

--- a/book/_credits.yml
+++ b/book/_credits.yml
@@ -1,0 +1,169 @@
+# Credits
+book:
+  credit:
+    author:
+      - Robert Lanzafame
+      - Tom van Woudenberg
+      - Sandra Verhagen
+    title: _config.yml
+    license: CC BY 4.0
+    copyright: Delft University of Technology
+    type: editor-author
+
+
+sources:
+  modelling_concepts:
+    author:
+      - Alessandro Cabboi
+      - Patricia Mares Nasarre
+      - Robert Lanzafame
+    acknowledgement:
+      - name: João Moura Pereira de Lucas Teixeira
+        contribution: Created first draft of pages from powerpoint slides.
+    type: internal
+    note: |
+      Alessandro made most of the slides, which were transcribed by João in 2023. Robert and Patricia modified and re-wrote some material into book format for 2023. Patricia especially added to the GoF page.
+      
+      Status of figures is unclear.
+
+  uncertainty_propagation:
+    license: CC BY 4.0
+    copyright: Delft University of Technology
+    author:
+      - Sandra Verhagen
+    title: Propagation of Uncertainty
+    acknowledgement:
+      - name: Robert Lanzafame, Patricia Mares Nasarre, Max Ramgraber
+        contribution: reviewed, commented and/or modified content
+      - name: Antonio Magherini
+        contribution: converted the slides and exercises to book format
+    resource:
+      - name: Max Ramgraber
+        what: interactive figure
+        where: https://mude.citg.tudelft.nl/2024/book/_static/elements/element_2D_Gaussian.html
+        license: CC BY 4.0
+        copyright: Delft University of Technology
+      - name: Robert Lanzafame, Patricia Mares Nasarre
+        what: page
+        where: book/propagation_uncertainty/uncertainty.md
+        license: CC BY 4.0
+        copyright: Delft University of Technology
+    type: internal
+
+  observation_theory:
+    author:
+      - Sandra Verhagen
+    type: internal
+    note: |
+      
+
+  numerical_modelling:
+    author:
+      - Jaime
+      - Justin Pitman
+      - more
+    type: internal
+    acknowledgements:
+    isabel, mona
+
+  continuous_distributions:
+    author:
+      - Patricia Mares Nasarre
+      - ???
+    type: internal
+    note: |
+      Not sure if/when we move it to another book, and how to handle that.
+
+  multivariate_distributions:
+    author:
+      - Robert Lanzafame
+      - Patricia Mares Nasarre
+    type: internal
+    note: |
+      Not sure if/when we move it to another book, and how to handle that.
+
+  finite_volume_method:
+    author:
+      - Robert Lanzafame
+      - Jaime Arriaga Garcia
+    type: internal
+    license: CC BY
+
+  finite_element_method:
+    author:
+      - Frans van der Meer
+      - Oriol?
+      - Martin?
+    type: external
+    license: CC-BY (but not yet confirmed?)
+
+  machine_learning:
+    title: Introduction to Machine Learning
+    author:
+      - Iuri Rocha
+      - Anne Poot
+      - Joep Storm
+      - Leon Riccius
+
+  signal_processing:
+    title: Signal Processing
+    author:
+      - Christiaan Tiberius
+    acknowledgement:
+      - name: Max Mulder
+        contribution: being a signal processing soul-mate, sparring-partner and TU Delft colleague of the author who co-shaped the material, indirectly, through collaboration since early 2000's.
+      - name: João Moura Pereira de Lucas Teixeira
+        contribution: created first draft of pages from powerpoint slides.
+      - name: Antonio Magherini
+        contribution: reviewed, commented and/or modified content
+      - name: Jelle Knibbe
+        contribution: reviewed, commented and/or modified content of original powerpoint slides.
+    type: internal
+    note:
+      - id: other_book
+        public: true
+        text: |
+          The material in this chapter will be closely related to a future book written by Christiaan Tiberius and Max Mulder (late 2025 target publishing date, via TU Delft Open Publishing).
+      - text: |
+          Note from Christian about the chapter and Max Mulder: I would consider one more person here, namely prof Max Mulder from Aerospace Engineering, as my signal processing soul-mate, sparring-partner and TU Delft colleague...Long time ago we developed and taught a course on this subject together, at Aerospace. We kept in touch (and as you know, we’re actually preparing, together, an Open Textbook on just this subject, hopefully appearing by the end of this year). So, directly his contribution is zero, but indirectly, he co-shaped this material. To say, my way of approaching and teaching signal processing has been determined in a large part by our joint teaching at that time (20 years ago).
+      - text: |
+          Robert went through the figures quickly but asked Christian to double-check via [Issue 45](https://github.com/TUDelft-MUDE/book/issues/45)
+    resources:
+      - name: unitycircle
+        what: animated figure
+        filename: unitycircle.gif
+        filepath: https://files.mude.citg.tudelft.nl/
+        where: book/2024/signal_processing/fourier_real.md
+        source_url: https://commons.wikimedia.org/wiki/File:Unitycircle-complex.gif
+        bibtex_key: BFD
+        license: CC BY SA 4.0
+
+  time_series:
+    title: Time Series Analysis
+    author:
+      - Alireza Amiri-Simkooei
+      - Christiaan Tiberius
+      - Sandra Verhagen
+    acknowledgement:
+      - name: João Moura Pereira de Lucas Teixeira
+        contribution: Created first draft of pages from powerpoint slides
+      - name: Antonio Magherini
+        contribution: reviewed, commented and/or modified content
+      - name: Berend Bouvy
+        contribution: created and improved many of the exercises and interactive pages
+    note:
+      - text: |
+          Alireza Amiri-Simkooei created the main framework of this chapter, which was then revised by Sandra and Christian.
+    resource:
+      - name: cover
+        what: figure
+        filename: tsa_cover.png
+        filepath: https://files.mude.citg.tudelft.nl/
+        where: book/2024/time_series/intro.md
+        source_url: https://www.researchgate.net/profile/Peter-Marcotullio/publication/330090901_Sustainable_development_poverty_eradication_and_reducing_inequalities_In_Global_warming_of_15C_An_IPCC_Special_Report/links/6386062b48124c2bc68128da/Sustainable-development-poverty-eradication-and-reducing-inequalities-In-Global-warming-of-15C-An-IPCC-Special-Report.pdf
+      - name: trend
+        what: figure
+        filename: trend.png
+        filepath: https://files.mude.citg.tudelft.nl/
+        where: book/2024/time_series/components.md
+        source_url: https://www.cmar.csiro.au/sealevel/sl_hist_last_decades.html

--- a/book/_credits.yml
+++ b/book/_credits.yml
@@ -63,13 +63,30 @@ sources:
       
 
   numerical_modelling:
+    name: PDEs and the Finite Volume Method
     author:
-      - Jaime
-      - Justin Pitman
-      - more
+      - Jaime Arriaga Garcia
+      - Justin Pittman
+      - Robert Lanzafame
     type: internal
     acknowledgements:
-    isabel, mona
+      - name:
+          - Isabel Slingerland
+          - Mona Devos
+        contribution: critical feedback and development of exercises, figures and related content.
+      - name:
+          - Dhruv Mehta
+          - Ajay Jagadeesh
+        contribution: feedback on structure, content.
+    resource:
+      - name: Deltares
+        name_ref: NumericalMethodsRiver
+        what: animated figure (gif)
+        where: book\numerical_methods\overview.md
+        source: https://files.mude.citg.tudelft.nl/NumericalMethodsRiver.gif
+        license: unclear
+        copyright: Deltares
+        note: Original caption from Jaime "Cool numerical model of the Yamuna river. Thanks to Amgad Omer (Deltares).""
 
   continuous_distributions:
     author:
@@ -92,7 +109,13 @@ sources:
       - Robert Lanzafame
       - Jaime Arriaga Garcia
     type: internal
-    license: CC BY
+    acknowledgements:
+      - name:
+          - Isabel Slingerland
+          - Mona Devos
+        contribution: critical feedback and development of exercises, figures and related content.
+      - name: Dhruv Mehta
+        contribution: providing a first draft of the chapter structure and contents.
 
   finite_element_method:
     title: Finite Elements in Civil Engineering and Geosciences

--- a/book/_credits.yml
+++ b/book/_credits.yml
@@ -9,6 +9,11 @@ book:
     license: CC BY 4.0
     copyright: Delft University of Technology
     type: editor-author
+  version:
+    type: semantic-year
+    year: 2024
+  
+
 
 
 sources:
@@ -96,6 +101,45 @@ sources:
       - Martin?
     type: external
     license: CC-BY (but not yet confirmed?)
+
+  optimization:
+    title: Optimization
+    author:
+      - Gonçalo Homem de Almeida Correia
+      - Maria Nogal Macho
+      - Bahman Madadi
+      - Jie Gao
+    type: internal
+    note:
+      - id: authorship
+        public: true
+        text: |
+          Gonçalo Homem de Almeida Correia created most of the material, as well as the overall structure of this chapter. Maria Nogal Macho and Bahman Ahmadi made contributions to various parts of the material. Bahman Ahmadi developed the exercises in Python and Jupyter notebooks. Jie Gao created the genetic algorithm material.
+      - text: |
+          Gonçalo instructions via email to Robert, April 18: Most of that material was created by me in the University of Coimbra and here [TUD]. But there’s material of Bahman Ahmadi, Maria Nogal, Jie Gao, etc.
+      - text: |
+          There are two types of files to consider in this chapter: 1) external files related to the Project (see resource below), and 2) stripped notebooks (for download link replacer). Each type have had special notes added in the CREDIT comment (text search "source: optimization").
+    acknowledgement:
+      - name:
+          - Jialei Ding
+          - Nadia Pourmohammadzia
+        contribution: reviewed material and made improvements to the traffic exercise.
+      - name: Tom van Woudenberg
+        contribution: edited text and improved content and structure for online interactive textbook format.
+      - name: João Moura Pereira de Lucas Teixeira
+        contribution: created first draft of pages from powerpoint slides.
+    resource:
+      - name: Road Network Design Problem
+        what: Jupyter notebooks and associated files
+        where:
+          - book\optimization\project.md
+          - book\book\optimization\Project_MILP.ipynb
+          - book\optimization\Project_GA.ipynb
+        source: URL not yet available
+        license: CC BY 4.0
+        copyright: Delft University of Technology
+        note: |
+          Not yet published. Only the md and ipynb files are included here, not the py files. Once published, update URL and citation. Citation will be Ahmadi, et al. (2024) and the full bib entry will be similar to a MUDE chapter (e.g., Ahmadi...in Lanzafame et al., (2024) MUDE Files...)
 
   machine_learning:
     title: Introduction to Machine Learning

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -18,7 +18,7 @@ parts:
     - file: propagation_uncertainty/overview
       sections:
       - file: propagation_uncertainty/00a_CovCorr.md
-      - file: propagation_  uncertainty/00b_MultivariateNormal
+      - file: propagation_uncertainty/00b_MultivariateNormal
       - file: propagation_uncertainty/uncertainty
       - file: propagation_uncertainty/01_ErrorPropagation.md
       - file: propagation_uncertainty/02_LinearPropagation.md

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -2,24 +2,23 @@ format: jb-book
 root: intro
 
 parts:
+  - caption: Introduction
+    numbered: false
+    chapters:
+    - file: overview
   - caption: Q1 Topics
     numbered: 2
     chapters: 
     - file: modelling/overview
-      title: Modelling Concepts
       sections:
       - file: modelling/classification
-        title: Classification
       - file: modelling/decisions
-        title: Decisions
       - file: modelling/validate_verify
-        title: Calibration, Validation & Verification
       - file: modelling/gof
-        title: Goodness of Fit
     - file: propagation_uncertainty/overview
       sections:
       - file: propagation_uncertainty/00a_CovCorr.md
-      - file: propagation_uncertainty/00b_MultivariateNormal
+      - file: propagation_  uncertainty/00b_MultivariateNormal
       - file: propagation_uncertainty/uncertainty
       - file: propagation_uncertainty/01_ErrorPropagation.md
       - file: propagation_uncertainty/02_LinearPropagation.md
@@ -50,7 +49,6 @@ parts:
       - file: observation_theory/99_NotationFormulas
     
     - file: numerical_methods/overview
-      title: Numerical Modelling
       sections:
       - file: numerical_methods/1-revision-of-concepts.ipynb
       - file: numerical_methods/2-derivative.ipynb
@@ -65,12 +63,10 @@ parts:
       - file: numerical_methods/9-starting_with_PDEs.ipynb
 
     - file: probability/Reminder_intro
-      title: Univariate Continuous Distributions
       sections:
       - file: probability/PDF_CDF
       - file: probability/empirical
       - file: probability/Param_distr.md
-        title: Parametric distributions
         sections: 
         - file: probability/Gaussian.md
         - file: probability/other_distr.md
@@ -80,7 +76,6 @@ parts:
         - file: probability/Lognormal.md
         - file: probability/summary.md
       - file: probability/fitting.md
-        title: Fitting parametric distributions
         sections: 
         - file: probability/moments.md
         - file: probability/MLE_1.ipynb
@@ -88,18 +83,12 @@ parts:
       - file: probability/Loc-scale.ipynb
 
     - file: multivariate/overview
-      title: Multivariate Distributions
       sections:
       - file: multivariate/events
-        title: Discrete Events
       - file: multivariate/variables
-        title: Continuous Variables
       - file: multivariate/gaussian
-        title: Multivariate Gaussian
       - file: multivariate/nongaussian
-        title: Non-Gaussian Distributions
       - file: multivariate/design
-        title: Practical Applications
         sections:
         - file: multivariate/design/one-random-variable
         - file: multivariate/design/two-random-variables
@@ -115,19 +104,13 @@ parts:
     numbered: 2
     chapters:
     - file: fvm/intro.md
-      title: Finite Volume Method
       sections:
       - file: fvm/getting_started_new.ipynb
-        title: Getting Started
       - file: fvm/fvm.ipynb
-        title: Finite Volume Method
       - file: fvm/advection_1.ipynb
-        title: Advection and Diffusion
       - file: fvm/unstructured_meshes.ipynb
-        title: Unstructured Meshes
 
     - file: fem/intro.md
-      title: Finite Element Method
       sections:
       - file: fem/strong.md
       - file: fem/weak.md
@@ -139,52 +122,34 @@ parts:
       - file: fem/isoparametric_mapping.md
 
     - file: signal/intro.md
-      title: Signal Processing
       sections:
       - file: signal/fourier_real
-        title: Fourier Series
         sections:
         - file: signal/fourier_nb
-          title: Square Wave Example
       - file: signal/fourier_complex
-        title: Complex Fourier Series
       - file: signal/fourier_transf
-        title: Fourier Transform
       - file: signal/sampling
-        title: Sampling
       - file: signal/dft
-        title: Discrete Fourier Transform
       - file: signal/spectral_est
-        title: Spectral Estimation
       - file: signal/videos
-        title: Supplementary Videos
 
     - file: time_series/intro.md
-      title: Time Series Analysis
       sections:
       - file: time_series/components.md
-        title: "Time Series components"
         sections:
         - file: time_series/exercise1.ipynb
       - file: time_series/noise.ipynb
-        title: "Noise and stochastic model"
       - file: time_series/modelling
-        title: "Time Series modelling and estimation"
         sections:
         - file: time_series/fit_BLUE.ipynb
       - file: time_series/stationarity
-        title: "Stationarity"
       - file: time_series/acf
-        title: "Autocovariance function (ACF)"
       - file: time_series/ar.ipynb
-        title: "AutoRegressive (AR) process"
         sections:
         - file: time_series/ar_exercise.ipynb
       - file: time_series/forecasting
-        title: "Time Series forecasting"
   
     - file: optimization/overview
-      title: Optimization
       sections:
       - file: optimization/origins
       - file: optimization/general
@@ -203,16 +168,13 @@ parts:
       - file: optimization/some_constraints
       - file: optimization/genetic_algorithm
       - file: optimization/airlines.ipynb
-        title: Airline Exercise (Optional)
         # START REMOVE-FROM-PUBLISH
       - file: optimization/performance
-        title: Performance Considerations in LP (Optional)
         sections:
         - file: optimization/airlines_performance.ipynb
         - file: optimization/performance_generic_LP.ipynb
         # END REMOVE-FROM-PUBLISH
       - file: optimization/project
-        title: Road Network Design Problem (GA)
         sections:
         - file: optimization/Project_MILP.ipynb
         - file: optimization/Project_GA.ipynb
@@ -228,42 +190,26 @@ parts:
       - file: ml/review
 
     - file: eva/intro.md
-      title: Extreme Value Analysis
       sections:
       - file: eva/extreme.md
-        title: Concept of Extreme
         sections:
         - file: eva/RT.md
-          title: Return period
         - file: eva/sampling.md
-          title: Sampling extremes
       - file: eva/BM_GEV.md
-        title: Block Maxima & GEV
         sections:
         - file: eva/BM.md
-          title: Block Maxima
         - file: eva/Asymptotic.md
-          title: Asymptotic theorem
         - file: eva/GEV.md
-          title: GEV distribution
         - file: eva/RP_Binomial.md
-          title: RT & Design Life
       - file: eva/POT_GPD.md
-        title: POT & GPD
         sections:
         - file: eva/POT.md
-          title: Peak Over Threshold
         - file: eva/Poisson.md
         - file: eva/Threshold.md
-          title: Parameters selection
         - file: eva/GPD.md
-          title: Intro to GPD
         - file: eva/GPD2.md
-          title: Practicalities for GPD
         - file: eva/RP_Poisson.md
-          title: Revisiting RT
       - file: eva/extra.md
-        title: Supplementary Material
         sections:
         - file: eva/Bernoulli.md
         - file: eva/videos.md
@@ -279,7 +225,6 @@ parts:
       #   - file: pd/prob-design/example-river-system.md
       sections:
       - file: pd/risk-analysis/overview.md
-        title: Risk Introduction
         sections:
         - file: pd/risk-analysis/definition.md
         - file: pd/risk-analysis/steps.md

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -2,10 +2,10 @@ format: jb-book
 root: intro
 
 parts:
-  - caption: Introduction
-    numbered: false
-    chapters:
-    - file: overview
+  # - caption: Introduction
+  #   numbered: false
+  #   chapters:
+  #   - file: overview
   - caption: Q1 Topics
     numbered: 2
     chapters: 

--- a/book/credits.md
+++ b/book/credits.md
@@ -61,6 +61,27 @@ Credits are provided here for chapters and pages that are released under the lic
 >
 > Special thanks goes to João Moura Pereira de Lucas Teixeira, who created first draft of pages from powerpoint slides.
 
+(uncertainty_propagation_credit)=
+### Chapter: Uncertainty Propagation
+
+> {ref}`01_errorprop` is written by Sandra Verhagen.
+>
+> Special thanks goes to:
+> - Robert Lanzafame, Patricia Mares Nasarre and Max Ramgraber, who reviewed, commented and/or modified content. Robert and Patricia wrote the page {ref}`uncertainty_classification`.
+> - Sophie Keemink, Caspar Jungbacker and Thirza Feenstra, who provided feedback and helped develop exercises.
+> - Antonio Magherini, who created first draft of pages from powerpoint slides.
+>
+> This chapter includes interactive figures created by Max Ramgraber ([maxramgraber.com/interactive](https://www.maxramgraber.com/interactive)).
+
+(observation_theory_credit)=
+### Chapter: Observation Theory
+
+> {ref}`OT` is written by Sandra Verhagen.
+>
+> Special thanks goes to:
+> - Peter Teunissen and Christiaan Tiberius who co-shaped the material, indirectly, through collaboration with the author as TU Delft colleagues.
+> - Sophie Keemink, Caspar Jungbacker and Thirza Feenstra, who provided feedback and helped develop exercises.
+
 (numerical_modelling_credit)=
 ### Chapter: Numerical Modelling
 
@@ -72,10 +93,19 @@ Credits are provided here for chapters and pages that are released under the lic
 >
 > {numref}`NumericalMethodsRiver` is included on page {ref}`numerical_modelling` but is _not_ included under the CC BY license of this book and cannot be reused without explicit permission from the original copyright holder (Deltares). Original content is used here with explicit permission of Amgad Omer on behalf of Deltares.
 
+(distributions_credit)=
+### Chapters: Univariate and Multivariate Continuous Distributions
+
+> {ref}`cont_dist` and {ref}`mult_dist` are written by Patricia Mares Nasarre and Robert Lanzafame.
+>
+> Special thanks goes to Oswaldo Morales Napoles and Elisa Ragno for suggestions on the theoretical and didactic framework, as well as critical feedback and review.
+>
+> Pages {ref}`prob_design_1_rv` and {ref}`prob_design_2_rv` are from the Chapter _Probabilistic Design_ {cite:p}`lanzafame2024-pd` from the book Risk and Reliability for Engineers {cite:p}`lanzafame2024`, published  with a CC BY license. Files are included without modification.
+>
+> This chapter includes interactive figures created by Max Ramgraber ([maxramgraber.com/interactive](https://www.maxramgraber.com/interactive)).
 
 (finite_volume_method_credit)=
 ### Chapter: PDEs and the Finite Volume Method
-
 
 > {ref}`fvm` is written by Robert Lanzafame and Jaime Arriaga Garcia.
 >
@@ -117,6 +147,7 @@ Credits are provided here for chapters and pages that are released under the lic
 >
 > Special thanks goes to:
 > - Berend Bouvy, who created a number ofinteractive figures and exercises, as well as provided critical feedback.
+> - Serge Kaplev, who provided critical feedback and suggestions for the theoretical content.
 > - Antonio Magherini, who created the first draft material from powerpoint slides and prepared notebooks as exercises.
 > 
 > The following resources are used in this chapter but are _not_ included under the CC BY license of this book and cannot be reused without explicit permission from the original copyright holder:
@@ -142,37 +173,22 @@ Credits are provided here for chapters and pages that are released under the lic
 
 > {ref}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
 
-(generic_credit)=
-### `<resource_type>`: `<title>`
-% CREDIT-NOTE: note that the title ref is not included because
-%   the tag is displayed in the rhs toc.
-% Future dev may use templating to automatically include the
-%   right text in these sections
+(extreme_value_analysis_credit)=
+### Chapter: Extreme Value Analysis
 
-> `<title>` is written by `<authors>`.
-> 
-> Special thanks goes to `<name>`, who `<contribution>`.
+> {ref}`eva` is written by Patricia Mares Nasarre.
 >
-> _or_
->
-> Special thanks goes to:
-> - `<name>`, who `<contribution>`
-> - `<name>`, who `<contribution>`.
->
-> Note: `<note-public>`
->
-> The following resources are used in this `<resource_type>` but are _not_ included under the CC BY license of this book and cannot be reused without explicit permission from the original copyright holder:
-> - `resource_type>` `<resource>` is used in `<page>` (not modified). Original content licensed under `<license>`.
-> - `resource_type>` `<resource>` is used in `<page>` and `<modification>`. Original content licensed under `<license>`.
-> - `resource_type>` `<resource>` (`<bibtex>`) is used in `<page>` (unmodified). Original content licensed under `<license>` and is available `<resource_location>`.
-> - ...
-> 
+> Special thanks goes to Oswaldo Morales Napoles, Elisa Ragno and Robert Lanzafame for suggestions on the theoretical and didactic framework, as well as critical feedback and review.
 
 (external_resources_credits)=
 ## External resources
 
 The following chapters and pages are included directly from an external resource, are not included under the CC BY license of this book and cannot be reused without explicit permission from the original copyright holder. Unless otherwise noted below, the contents have not been edited by the authors of this book.
 
+(risk_analysis_credit)=
+### Chapter: Risk Analysis
+
+> {ref}`risk` resuses the Chapters _Risk Analysis_ {cite:p}`lanzafame2024-risk` and _Risk Evaluation_ {cite:p}`lanzafame2024-risk-eval` and associated exercises from the book _Risk and Reliability for Engineers_ {cite:p}`lanzafame2024`, published with a CC BY license. Files were modified to provide short introduction and explanation for readers (i.e., MUDE students).
 
 ### Programming Chapters
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -80,7 +80,7 @@ Credits are provided here for chapters and pages that are released under the lic
 >
 > Special thanks goes to:
 > - Peter Teunissen and Christiaan Tiberius who co-shaped the material, indirectly, through collaboration with the author as TU Delft colleagues.
-> - The book _Adjustment theory: an introduction_ {cite:p}`adjustment_thoery` and _Testing theory: an introduction_ {cite:p}`testing_theory` which provided the framework for this chapter.
+> - The book _Adjustment theory: an introduction_ {cite:p}`adjustment_theory` and _Testing theory: an introduction_ {cite:p}`testing_theory` which provided the framework for this chapter.
 > - Sophie Keemink, Caspar Jungbacker and Thirza Feenstra, who provided feedback and helped develop exercises.
 
 (numerical_modelling_credit)=

--- a/book/credits.md
+++ b/book/credits.md
@@ -54,9 +54,15 @@ CC BY conditions are _not_ applicable to some resources included in this book wh
 
 Credits are provided here for chapters and pages that are released under the license of this book (internal resources). Use the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
 
+(modelling_concepts_credit)=
+### Chapter: Modelling Concepts
+
+> {ref}`modelling_concepts` is written by Alessandro Cabboi, Patricia Mares Nasarre and Robert Lanzafame.
+>
+> Special thanks goes to João Moura Pereira de Lucas Teixeira, who created first draft of pages from powerpoint slides.
+
 (numerical_modelling_credit)=
 ### Chapter: Numerical Modelling
-
 
 > {ref}`numerical_modelling` is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame.
 >
@@ -77,12 +83,22 @@ Credits are provided here for chapters and pages that are released under the lic
 > - Isabel Slingerland and Mona Devos for critical feedback and development of exercises, figures and related content.
 > - Dhruv Mehta for providing a first draft of the chapter structure and contents.
 
+
+(finite_element_method_credit)=
+### Chapter: Finite Element Method
+
+> {ref}`finite_element_method` is written by Frans van der Meer. 
+>
+> _The material in this chapter is also incorporated in an in-depth book "Finite Elements in Civil Engineering and Geosciences" by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur which can be found [here](interactivetextbooks.citg.tudelft.nl/computational-modelling)._
+>
+> Special thanks goes to Lex Niessen who greatly assisted in developing material on the finite element method for the first edition of MUDE, which was the starting point for this chapter. 
+
 (signal_processing_credit)=
 ### Chapter: Signal Processing
 
 > {ref}`signal_processing` is written by Christiaan Tiberius.
 >
-> _The material in this chapter is closely related to an in-depth book "Engineering signal analysis - from Fourier to filtering" by Christiaan Tiberius and Max Mulder (TU Delft Open Publishing, 2025)._
+> _The material in this chapter is related to an in-depth book "Engineering signal analysis - from Fourier to filtering" by Christiaan Tiberius and Max Mulder (TU Delft Open Publishing, 2025)._
 >
 > Special thanks goes to:
 > - Max Mulder for being a signal processing soul-mate, sparring-partner and TU Delft colleague of the author who co-shaped the material, indirectly, through collaboration since early 2000's.
@@ -91,6 +107,21 @@ Credits are provided here for chapters and pages that are released under the lic
 > - Antonio Magherini, who reviewed, commented and/or modified content.
 >
 > {numref}`unitycircle` is included on page {ref}`fourier_real` but is _not_ included under the CC BY license of this book and cannot be reused without explicit permission from the original copyright holder. Original content licensed under CC BY-SA 4.0 by {cite:t}`BFG` and can be found [here](https://commons.wikimedia.org/wiki/File:Unitycircle-complex.gif); used here without modification.
+
+(time_series_analysis_credit)=
+### Chapter: Time Series Analysis
+
+> {ref}`tsa` is written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen.
+>
+> _The initial framework and contents of this chapter were created by Alireza Amiri-Simkooei, which was then revised and updated by Sandra and Christian._
+>
+> Special thanks goes to:
+> - Berend Bouvy, who created a number ofinteractive figures and exercises, as well as provided critical feedback.
+> - Antonio Magherini, who created the first draft material from powerpoint slides and prepared notebooks as exercises.
+> 
+> The following resources are used in this chapter but are _not_ included under the CC BY license of this book and cannot be reused without explicit permission from the original copyright holder:
+> - {numref}`cover` is used on page {ref}`tsa` (not modified) and is from {cite:t}`ipcc2018`.
+> - {numref}`trend` is used on page {ref}`components` (not modified) and is from {cite:t}`csiro`
 
 (optimization_credit)=
 ### Chapter: Optimization
@@ -142,10 +173,6 @@ Credits are provided here for chapters and pages that are released under the lic
 
 The following chapters and pages are included directly from an external resource, are not included under the CC BY license of this book and cannot be reused without explicit permission from the original copyright holder. Unless otherwise noted below, the contents have not been edited by the authors of this book.
 
-(finite_element_method_credit)=
-### Chapter: Introduction to Finite Elements
-
->{ref}`finite_element_method` is from "Finite Elements in Civil Engineering and Geosciences" by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur; specifically, the chapter "Introduction to finite elements." The original source can be accessed at [interactivetextbooks.citg.tudelft.nl/computational-modelling](https://interactivetextbooks.citg.tudelft.nl/computational-modelling) and will soon be published with a CC BY license.
 
 ### Programming Chapters
 
@@ -157,7 +184,6 @@ The pages listed here are not
 
 - page [](./external/learn-python/book/08/sympy.ipynb). Original content licensed under CC BY.
 - Page REFERENCE are from CITATION/LINK. Original content licensed under CC BY.
-
 
 ## Contact
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -122,7 +122,7 @@ The following chapters and pages are included directly from an external resource
 (finite_element_method_credit)=
 ### Chapter: Introduction to Finite Elements
 
-> _WIP_
+>{ref}`finite_element_method` is from "Finite Elements in Civil Engineering and Geosciences" by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur; specifically, the chapter "Introduction to finite elements." The original source can be accessed at [interactivetextbooks.citg.tudelft.nl/computational-modelling](https://interactivetextbooks.citg.tudelft.nl/computational-modelling) and will soon be published with a CC BY license.
 
 ### Programming Chapters
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -80,6 +80,7 @@ Credits are provided here for chapters and pages that are released under the lic
 >
 > Special thanks goes to:
 > - Peter Teunissen and Christiaan Tiberius who co-shaped the material, indirectly, through collaboration with the author as TU Delft colleagues.
+> - The book _Adjustment theory: an introduction_ {cite:p}`adjustment_thoery` and _Testing theory: an introductino_ {cite:p}`testing_theory` which provided the framework for this chapter.
 > - Sophie Keemink, Caspar Jungbacker and Thirza Feenstra, who provided feedback and helped develop exercises.
 
 (numerical_modelling_credit)=

--- a/book/credits.md
+++ b/book/credits.md
@@ -42,16 +42,15 @@ And in the end, none of this would have happened if it weren't for the quick mee
 
 ## License
 
-This manual is [CC BY 4.0 licensed](https://creativecommons.org/licenses/by/4.0/) allowing you to share and adapt the material, as long as the source is named. External resources that are reused in this manual are listed below.
+This manual is [CC BY 4.0 licensed](https://creativecommons.org/licenses/by/4.0/) allowing you to share and adapt the material, as long as the source is named. Resources that are _not_ included under the CC BY license and external resources that are reused in this book are listed in the sections below.
 
 (not_cc_by)=
 ### Resources not under CC BY
 
-CC BY conditions are not applicable to: ...
+CC BY conditions are not applicable to the following resources included in this book. These resources cannot be reused without explicit permission from the original copyright holder.
 
-
-
-Note that REFERENCE/CITATION cannot be reused without explicit permission from the original copyright holder.
+In chapter CHAPTER:
+- RESOURCE
 
 (external_resources)=
 ### External resources

--- a/book/credits.md
+++ b/book/credits.md
@@ -54,6 +54,29 @@ CC BY conditions are _not_ applicable to some resources included in this book wh
 
 Credits are provided here for chapters and pages that are released under the license of this book (internal resources). Use the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
 
+(numerical_modelling_credit)=
+### Chapter: Numerical Modelling
+
+
+> {ref}`numerical_modelling` is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame.
+>
+> Special thanks goes to:
+> - Isabel Slingerland and Mona Devos for critical feedback and development of exercises, figures and related content.
+> - Dhruv Mehta and Ajay Jagadeesh for feedback on structure, content.
+>
+> {numref}`NumericalMethodsRiver` is included on page {ref}`numerical_modelling` but is _not_ included under the CC BY license of this book and cannot be reused without explicit permission from the original copyright holder (Deltares). Original content is used here with explicit permission of Amgad Omer on behalf of Deltares.
+
+
+(finite_volume_method_credit)=
+### Chapter: PDEs and the Finite Volume Method
+
+
+> {ref}`fvm` is written by Robert Lanzafame and Jaime Arriaga Garcia.
+>
+> Special thanks goes to:
+> - Isabel Slingerland and Mona Devos for critical feedback and development of exercises, figures and related content.
+> - Dhruv Mehta for providing a first draft of the chapter structure and contents.
+
 (signal_processing_credit)=
 ### Chapter: Signal Processing
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -190,16 +190,12 @@ The following chapters and pages are included directly from an external resource
 
 > {ref}`risk` resuses the Chapters _Risk Analysis_ {cite:p}`lanzafame2024-risk` and _Risk Evaluation_ {cite:p}`lanzafame2024-risk-eval` and associated exercises from the book _Risk and Reliability for Engineers_ {cite:p}`lanzafame2024`, published with a CC BY license. Files were modified to provide short introduction and explanation for readers (i.e., MUDE students).
 
+(programming_credit)=
 ### Programming Chapters
 
-> Programming Chapters REFERENCE are from CITATION/LINK. Original content licensed under CC BY.
+The chapters in the Programming part of this book are reused from two sources: _Learn Programming for Engineers_ {cite:p}`learn-programming` and _Python for Engineers_ {cite:p}`learn-python`. Both books are published with a CC BY license and are available online at [teachbooks.io/learn-programming](https://teachbooks.io/learn-programming) and [teachbooks.io/learn-python](https://teachbooks.io/learn-python).
 
-### Individual External Pages
-
-The pages listed here are not 
-
-- page [](./external/learn-python/book/08/sympy.ipynb). Original content licensed under CC BY.
-- Page REFERENCE are from CITATION/LINK. Original content licensed under CC BY.
+All chapters are from _Learn Programming for Engineers_, except Chapters 1.6 and 1.8 (Errors and Sympy, respectively), which are from _Python for Engineers._ Content has been modified slightly to fit the MUDE context.
 
 ## Contact
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -54,6 +54,21 @@ CC BY conditions are _not_ applicable to some resources included in this book wh
 
 Credits are provided here for chapters and pages that are released under the license of this book (internal resources). Use the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
 
+(signal_processing_credit)=
+### Chapter: Signal Processing
+
+> {ref}`signal_processing` is written by Christiaan Tiberius.
+>
+> _The material in this chapter is closely related to an in-depth book "Engineering signal analysis - from Fourier to filtering" by Christiaan Tiberius and Max Mulder (TU Delft Open Publishing, 2025)._
+>
+> Special thanks goes to:
+> - Max Mulder for being a signal processing soul-mate, sparring-partner and TU Delft colleague of the author who co-shaped the material, indirectly, through collaboration since early 2000's.
+> - Jelle Knibbe, who reviewed, commented and/or modified content of original powerpoint slides.
+> - João Moura Pereira de Lucas Teixeira, created first draft of pages from powerpoint slides.
+> - Antonio Magherini, who reviewed, commented and/or modified content.
+>
+> {numref}`unitycircle` is included on page {ref}`fourier_real` but is _not_ included under the CC BY license of this book and cannot be reused without explicit permission from the original copyright holder. Original content licensed under CC BY-SA 4.0 by {cite:t}`BFG` and can be found [here](https://commons.wikimedia.org/wiki/File:Unitycircle-complex.gif); used here without modification.
+
 (optimization_credit)=
 ### Chapter: Optimization
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -23,18 +23,9 @@ This book is created using open source tools: it is a Jupyter Book that uses a n
 
 ## Acknowledgements
 
-This book has many contributors, many of whom are also key members of the MUDE Team:
+This book has many contributors, many of whom are also key members of the MUDE Team, as well as critical feedback from MUDE students. The sections below list the primary authors and contributors for each chapter, buit is unfortunately not possible to list all of the small contributions from various people from within and outside Delft University of Technology, not list all contributions in detail.
 
-- xxx
-- yyy
-- zzz
-- MUDE students 
-
-All from Delft University of Technology.
-
-This doesn't include small contributions from various people from within and outside Delft University of Technology.
-
-A better way to see the contributions is to check the [Contributors Page](https://github.com/TUDelft-MUDE/book/graphs/contributors) of the GitHub repository.
+A  better way to see the contributions is to check the [Contributors Page](https://github.com/TUDelft-MUDE/book/graphs/contributors) of the GitHub repository.
 
 A big "thank you" is also due to the Educational Management Team of the Civil Engineering and Geosciences Faculty at Delft University of Technology for giving the MUDE Team financial and organizational support during the early years of MUDE (especially 2022-2024), in particular Hans Welleman, Director of Education of the faculty. Without the freedom and support to experiment with new tools, this book (and [TeachBooks](https://teachbooks.io/) as well!) would not exist!
 
@@ -44,29 +35,78 @@ And in the end, none of this would have happened if it weren't for the quick mee
 
 This manual is [CC BY 4.0 licensed](https://creativecommons.org/licenses/by/4.0/) allowing you to share and adapt the material, as long as the source is named. Resources that are _not_ included under the CC BY license and external resources that are reused in this book are listed in the sections below.
 
-(not_cc_by)=
-### Resources not under CC BY
+If an author is not listed on a particular page, it is by the Editors (for example, the introduction page of some chapters).
 
-CC BY conditions are not applicable to the following resources included in this book. These resources cannot be reused without explicit permission from the original copyright holder.
-
-In chapter CHAPTER:
-- RESOURCE
+Auxiliary files such as figures, code, videos, etc, are included under the license of this book and should be attributed to the authors of the chapter or page where they are used, unless otherwise stated below or in the file itself. Text-based files (i.e., non-binary) are typically stored in the repository, within the subdirectory where the source file of the chapter or page is located. Binary files are stored in an FTP server (`https://files.mude.citg.tudelft.nl/<binary_file_name>`). Videos and quiz questions are stored in and served from YouTube and H5p; contact the MUDE Team directly if you are interested in source materials for these resources.
 
 (external_resources)=
-### External resources
+### External Resources
 
-Parts of this book are taken from other external resources and reused in various ways. If an author is not listed on a particular page, it is by the Editors, except as follows:
+Parts of this book are taken from other external resources and reused in various ways. Entire chapters or pages are listed individually in the {ref}`external_resources` section below. Resources that are used _within_ a page and/or are modified by MUDE authors are listed individually in the {ref}`internal_resources` section below.
 
-The following chapters/pages are included directly from an external resource and is not edited by MUDE authors:
+(credits_not_cc_by)=
+### Resources _not_ under CC BY
+
+CC BY conditions are _not_ applicable to some resources included in this book which resources cannot be reused without explicit permission from the original copyright holder. These resources are listed individually within the summary of each chapter or page.
+
+(internal_resources)=
+## Individual Chapters and Pages
+
+Credits are provided here for chapters and pages that are released under the license of this book (internal resources). Use the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
+
+(machine_learning_credit)=
+### Chapter: Introduction to Machine Learning
+% CREDIT-NOTE: note that the title ref is not included because
+%   the tag is displayed in the rhs toc.
+% Future dev may use templating to automatically include the
+%   right text in these sections
+
+> {ref}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
+
+(generic_credit)=
+### `<resource_type>`: `<title>`
+
+> `<title>` is written by `<authors>`.
+> 
+> Special thanks goes to `<name>` for `<contribution>`.
+>
+> _or_
+>
+> Special thanks goes to:
+>  - `<name>` for `<contribution>`
+>  - `<name>` for `<contribution>`.
+>
+> Note: `<note-public>`
+>
+> The following resources are used in this `<resource_type>` but are _not_ included under the CC BY license of this book and cannot be reused without explicit permission from the original copyright holder:
+> - `resource_type>` `<resource>` is used in `<page>` (not modified). Original content licensed under `<license>`.
+> - `resource_type>` `<resource>` is used in `<page>` and `<modification>`. Original content licensed under `<license>`.
+> - `resource_type>` `<resource>` (`<bibtex>`) is used in `<page>` (unmodified). Original content licensed under `<license>` and is available `<resource_location>`.
+> - ...
+> 
+
+(external_resources_credits)=
+## External resources
+
+The following chapters and pages are included directly from an external resource, are not included under the CC BY license of this book and cannot be reused without explicit permission from the original copyright holder. Unless otherwise noted below, the contents have not been edited by the authors of this book.
+
+(finite_element_method_credit)=
+### Chapter: Introduction to Finite Elements
+
+> _WIP_
+
+### Programming Chapters
+
+> Programming Chapters REFERENCE are from CITATION/LINK. Original content licensed under CC BY.
+
+### Individual External Pages
+
+The pages listed here are not 
 
 - page [](./external/learn-python/book/08/sympy.ipynb). Original content licensed under CC BY.
-- Programming Chapters REFERENCE are from CITATION/LINK. Original content licensed under CC BY.
 - Page REFERENCE are from CITATION/LINK. Original content licensed under CC BY.
 
-The following pages contain content written by others, part of which has been reused and/or modified by MUDE authors:
-- Pages REFERENCE and REFERENCE include text from CITATION that is used EXPLANATION. Original content licensed under CC BY. 
-- more as needed
 
+## Contact
 
-
-
+If you have questions on the content, contact the MUDE team at MUDE-CEG@tudelft.nl. If you have technical questions regarding this book, contact the IT-coordinator of MUDE (Tom): T.R.vanWoudenberg@tudelft.nl

--- a/book/credits.md
+++ b/book/credits.md
@@ -80,7 +80,7 @@ Credits are provided here for chapters and pages that are released under the lic
 >
 > Special thanks goes to:
 > - Peter Teunissen and Christiaan Tiberius who co-shaped the material, indirectly, through collaboration with the author as TU Delft colleagues.
-> - The book _Adjustment theory: an introduction_ {cite:p}`adjustment_thoery` and _Testing theory: an introductino_ {cite:p}`testing_theory` which provided the framework for this chapter.
+> - The book _Adjustment theory: an introduction_ {cite:p}`adjustment_thoery` and _Testing theory: an introduction_ {cite:p}`testing_theory` which provided the framework for this chapter.
 > - Sophie Keemink, Caspar Jungbacker and Thirza Feenstra, who provided feedback and helped develop exercises.
 
 (numerical_modelling_credit)=

--- a/book/credits.md
+++ b/book/credits.md
@@ -71,7 +71,7 @@ Credits are provided here for chapters and pages that are released under the lic
 > - Sophie Keemink, Caspar Jungbacker and Thirza Feenstra, who provided feedback and helped develop exercises.
 > - Antonio Magherini, who created first draft of pages from powerpoint slides.
 >
-> This chapter includes interactive figures created by Max Ramgraber ([maxramgraber.com/interactive](https://www.maxramgraber.com/interactive)).
+> {numref}`density_scatter_3` and {numref}`2D_Gaussian` are created by Max Ramgraber ([maxramgraber.com/interactive](https://www.maxramgraber.com/interactive)), which are published with a CC BY license and included in this book without modification.
 
 (observation_theory_credit)=
 ### Chapter: Observation Theory
@@ -101,9 +101,9 @@ Credits are provided here for chapters and pages that are released under the lic
 >
 > Special thanks goes to Oswaldo Morales Napoles and Elisa Ragno for suggestions on the theoretical and didactic framework, as well as critical feedback and review.
 >
-> Pages {ref}`prob_design_1_rv` and {ref}`prob_design_2_rv` are from the Chapter _Probabilistic Design_ {cite:p}`lanzafame2024-pd` from the book Risk and Reliability for Engineers {cite:p}`lanzafame2024`, published  with a CC BY license. Files are included without modification.
+> Pages {ref}`prob_design_1_rv` and {ref}`prob_design_2_rv` are from the Chapter _Probabilistic Design_ {cite:p}`lanzafame2024-pd` from the book Risk and Reliability for Engineers {cite:p}`lanzafame2024`, published with a CC BY license. Files are included without modification.
 >
-> This chapter includes interactive figures created by Max Ramgraber ([maxramgraber.com/interactive](https://www.maxramgraber.com/interactive)).
+> {numref}`density_scatter_3`, {numref}`pdf_cdf`, {numref}`pdf_cdf_2`, {numref}`density_scatter` and {numref}`density_scatter_2` are created by Max Ramgraber ([maxramgraber.com/interactive](https://www.maxramgraber.com/interactive)), which are published with a CC BY license and included in this book without modification.
 
 (finite_volume_method_credit)=
 ### Chapter: PDEs and the Finite Volume Method

--- a/book/credits.md
+++ b/book/credits.md
@@ -54,27 +54,41 @@ CC BY conditions are _not_ applicable to some resources included in this book wh
 
 Credits are provided here for chapters and pages that are released under the license of this book (internal resources). Use the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
 
+(optimization_credit)=
+### Chapter: Optimization
+
+> {ref}`optimization` is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi.
+>
+> _Gonçalo Homem de Almeida Correia created most of the material. Maria Nogal Macho and Bahman Ahmadi made contributions to various parts. Bahman Ahmadi developed the exercises in Python and Jupyter notebooks. Jie Gao created the genetic algorithm material._
+>
+> Special thanks goes to:
+> - Jialei Ding and Nadia Pourmohammadzia, who reviewed material and made improvements to the traffic exercise.
+> - Tom van Woudenberg, who edited text and improved content and structure for online interactive textbook format.
+> - João Moura Pereira de Lucas Teixeira, who created first draft of pages from powerpoint slides.
+>
+> The {ref}`optimization_project` pages are included in this chapter but are _not_ included under the CC BY license of this book; they are in-class exercises that will be shared by the authors of this book as part of a future publication (also under a CC BY license; citation will be provided here after publication).
+
 (machine_learning_credit)=
 ### Chapter: Introduction to Machine Learning
-% CREDIT-NOTE: note that the title ref is not included because
-%   the tag is displayed in the rhs toc.
-% Future dev may use templating to automatically include the
-%   right text in these sections
 
 > {ref}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
 
 (generic_credit)=
 ### `<resource_type>`: `<title>`
+% CREDIT-NOTE: note that the title ref is not included because
+%   the tag is displayed in the rhs toc.
+% Future dev may use templating to automatically include the
+%   right text in these sections
 
 > `<title>` is written by `<authors>`.
 > 
-> Special thanks goes to `<name>` for `<contribution>`.
+> Special thanks goes to `<name>`, who `<contribution>`.
 >
 > _or_
 >
 > Special thanks goes to:
->  - `<name>` for `<contribution>`
->  - `<name>` for `<contribution>`.
+> - `<name>`, who `<contribution>`
+> - `<name>`, who `<contribution>`.
 >
 > Note: `<note-public>`
 >

--- a/book/eva/intro.md
+++ b/book/eva/intro.md
@@ -1,4 +1,13 @@
+(eva)=
 # Extreme Value Analysis
+
+% START-CREDIT
+% source: extreme_value_analysis
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre. {ref}`Find out more here <extreme_value_analysis_credit>`.
+```
+% END-CREDIT
 
 The preceding chapters have focused on a variety of data-driven and physics-based modelling techniques which we primarily used to interpolate between known data (e.g., machine learning), or make predictions about phenomena where randomness did not play a significant role (e.g., finite volume or finite element methods applied to simple physics problems). Most of the methods and problems considered ignored (or greatly simplified) the stochastic nature of the underlying processes. When uncertainty was considered explicitly, it focused primarily on error and epistemic types, for example, the inclusion of various types of noise in Time Series Analysis, or measurement precision in Observation Theory. In these cases, the focus was on applications that were governed by variations around a central value (as opposed to the tails of the distribution), which are often modelled sufficiently using a Gaussian distribution.
 

--- a/book/fem/README.md
+++ b/book/fem/README.md
@@ -1,5 +1,7 @@
 # Note about FEM Materials
 
+June, 2025: Robert set up credits and attribution. Search `source: finite_element_method` to find sections of text/cell that were modified. Only files in fem subdir were modified (ignored files in Exercises and Tutorials because they did not show up in toc).
+
 Nov, 2024: Robert copy/pasted entire contents from computational modelling (commit hash [72b865ba](https://gitlab.tudelft.nl/interactivetextbooks-citg/computational-modelling/-/commit/72b865baafb124801b2661dfc33ab01eb7aa269f))
 - repo is https://gitlab.tudelft.nl/interactivetextbooks-citg/computational-modelling/
 - comp modelling subdirectory on `main` branch: `\computational-modelling-main\book\introduction\.`

--- a/book/fem/discrete.ipynb
+++ b/book/fem/discrete.ipynb
@@ -37,7 +37,7 @@
         "\n",
         "$$\n",
         "N_i(x) = \\left\\{ \\begin{array}{cl} \n",
-        "p(x), & x\\in\\Omega_k\\ \u2200 k\\in S_i\\\\\n",
+        "p(x), & x\\in\\Omega_k\\ ∀ k\\in S_i\\\\\n",
         "1, & x=x_i \\\\ \n",
         "0, & \\text{otherwise}\n",
         "\\end{array} \\right. \n",
@@ -1317,7 +1317,7 @@
                   "xaxis": "x2",
                   "y": [
                     0,
-                    3.156190865269053e-05,
+                    0.00003156190865269053,
                     0.00012623340357085464,
                     0.0002839717964472758,
                     0.0005047059561434998,
@@ -18036,7 +18036,7 @@
                     0.041068035621424775,
                     0.027355741136939032,
                     0.013643446652453317,
-                    -6.884783203242595e-05,
+                    -0.00006884783203242595,
                     -0.013781142316518141,
                     -0.027493436801004037,
                     -0.041205731285489766,
@@ -27680,7 +27680,7 @@
                     0.019642875800536114,
                     0.013088493442893326,
                     0.006534111085250538,
-                    -2.0271272392256845e-05,
+                    -0.000020271272392256845,
                     -0.006574653630035052,
                     -0.013129035987677846,
                     -0.019683418345320634,
@@ -46250,11 +46250,17 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": null,
+      "cell_type": "markdown",
       "metadata": {},
-      "outputs": [],
-      "source": []
+      "source": [
+        "% START-CREDIT\n",
+        "% source: finite_element_method\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/fem/discrete.ipynb
+++ b/book/fem/discrete.ipynb
@@ -46257,7 +46257,7 @@
         "% source: finite_element_method\n",
         "```{attributiongrey} Attribution\n",
         ":class: attribution\n",
-        "This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.\n",
+        "This chapter was written by Frans van der Meer. {ref}`Find out more here <finite_element_method_credit>`.\n",
         "```\n",
         "% END-CREDIT"
       ]

--- a/book/fem/intro.md
+++ b/book/fem/intro.md
@@ -1,11 +1,11 @@
 (finite_element_method)=
-# Introduction to finite elements
+# Finite Element Method
 
 % START-CREDIT
 % source: finite_element_method
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+This chapter was written by Frans van der Meer. {ref}`Find out more here <finite_element_method_credit>`.
 ```
 % END-CREDIT
 

--- a/book/fem/intro.md
+++ b/book/fem/intro.md
@@ -1,4 +1,13 @@
+(finite_element_method)=
 # Introduction to finite elements
+
+% START-CREDIT
+% source: finite_element_method
+```{attributiongrey} Attribution
+:class: attribution
+This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+```
+% END-CREDIT
 
 In this chapter we will introduce all the steps that are usually followed to solve a PDE using the finite element method, from the definition of the PDE to the solution of a linear system of equations. To make the learning curve ease, we focus on the simplest PDE for finite elements: the Poisson equation, first in 1D and then in 2D. Note that the laplacian operator with second derivatives in space that appears in th Poisson equation is an ingredient in many different engineering problems, so this is not only a convenient place to start but also a fundamental one.  
 

--- a/book/fem/isoparametric_mapping.md
+++ b/book/fem/isoparametric_mapping.md
@@ -231,6 +231,6 @@ $$
 % source: finite_element_method
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+This chapter was written by Frans van der Meer. {ref}`Find out more here <finite_element_method_credit>`.
 ```
 % END-CREDIT

--- a/book/fem/isoparametric_mapping.md
+++ b/book/fem/isoparametric_mapping.md
@@ -226,3 +226,11 @@ $$
 $$
 ```
 :::
+
+% START-CREDIT
+% source: finite_element_method
+```{attributiongrey} Attribution
+:class: attribution
+This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+```
+% END-CREDIT

--- a/book/fem/numerical_integration.md
+++ b/book/fem/numerical_integration.md
@@ -64,5 +64,10 @@ Gauss Integration points
 | $2$ |   $-\frac{1}{\sqrt{3}} ,  \frac{1}{\sqrt{3}} $ |  $1, 1$ | $2$ or $3$ |
 | $3$ | $-\frac{3}{\sqrt{5}}, 0, \frac{3}{\sqrt{5}}$ |  $\frac{5}{9}, \frac{8}{9}, \frac{5}{9}$ | $4$ or $5$ |
 
-
-
+% START-CREDIT
+% source: finite_element_method
+```{attributiongrey} Attribution
+:class: attribution
+This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+```
+% END-CREDIT

--- a/book/fem/numerical_integration.md
+++ b/book/fem/numerical_integration.md
@@ -68,6 +68,6 @@ Gauss Integration points
 % source: finite_element_method
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+This chapter was written by Frans van der Meer. {ref}`Find out more here <finite_element_method_credit>`.
 ```
 % END-CREDIT

--- a/book/fem/poisson2d.md
+++ b/book/fem/poisson2d.md
@@ -150,4 +150,10 @@ The finite element derivation for the Poisson equation in 2D follows the same li
 The derivation above also holds for 3D. Expressions and steps are exactly the same, although the interpretation of some of the symbols changes:  in 3D, $\Omega$ is a volume, $\Gamma$ is a surface and the $\bB$ matrix has three rows.
 ```
 
-
+% START-CREDIT
+% source: finite_element_method
+```{attributiongrey} Attribution
+:class: attribution
+This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+```
+% END-CREDIT

--- a/book/fem/poisson2d.md
+++ b/book/fem/poisson2d.md
@@ -154,6 +154,6 @@ The derivation above also holds for 3D. Expressions and steps are exactly the sa
 % source: finite_element_method
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+This chapter was written by Frans van der Meer. {ref}`Find out more here <finite_element_method_credit>`.
 ```
 % END-CREDIT

--- a/book/fem/shape.md
+++ b/book/fem/shape.md
@@ -192,6 +192,6 @@ name: 3dElements
 % source: finite_element_method
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+This chapter was written by Frans van der Meer. {ref}`Find out more here <finite_element_method_credit>`.
 ```
 % END-CREDIT

--- a/book/fem/shape.md
+++ b/book/fem/shape.md
@@ -187,3 +187,11 @@ name: 3dElements
 3D elements: hexahedral (left) and tetrahedral (right)
 ```
 :::
+
+% START-CREDIT
+% source: finite_element_method
+```{attributiongrey} Attribution
+:class: attribution
+This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+```
+% END-CREDIT

--- a/book/fem/strong.md
+++ b/book/fem/strong.md
@@ -73,3 +73,10 @@ As can be seen, the form of equation {eq}`1drod` is exactly the same as the 1D P
 <iframe src="https://tudelft.h5p.com/content/1292102761306552137/embed" aria-label="Boundary conditions for heat equation" width="1088" height="637" frameborder="0" allowfullscreen="allowfullscreen" allow="autoplay *; geolocation *; microphone *; camera *; midi *; encrypted-media *"></iframe><script src="https://tudelft.h5p.com/js/h5p-resizer.js" charset="UTF-8"></script>
 :::
 
+% START-CREDIT
+% source: finite_element_method
+```{attributiongrey} Attribution
+:class: attribution
+This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+```
+% END-CREDIT

--- a/book/fem/strong.md
+++ b/book/fem/strong.md
@@ -77,6 +77,6 @@ As can be seen, the form of equation {eq}`1drod` is exactly the same as the 1D P
 % source: finite_element_method
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+This chapter was written by Frans van der Meer. {ref}`Find out more here <finite_element_method_credit>`.
 ```
 % END-CREDIT

--- a/book/fem/videos.md
+++ b/book/fem/videos.md
@@ -53,3 +53,10 @@ To complete the story of how shape functions and numerical integration are usual
     <iframe width="560" height="315" src="https://www.youtube.com/embed/C_DtidjOPB4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 ```
 
+% START-CREDIT
+% source: finite_element_method
+```{attributiongrey} Attribution
+:class: attribution
+This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+```
+% END-CREDIT

--- a/book/fem/videos.md
+++ b/book/fem/videos.md
@@ -57,6 +57,6 @@ To complete the story of how shape functions and numerical integration are usual
 % source: finite_element_method
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+This chapter was written by Frans van der Meer. {ref}`Find out more here <finite_element_method_credit>`.
 ```
 % END-CREDIT

--- a/book/fem/weak.md
+++ b/book/fem/weak.md
@@ -126,6 +126,6 @@ The boundary condition $EA\frac{\partial u}{\partial x}=F$ at $x=L$ involves eva
 % source: finite_element_method
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+This chapter was written by Frans van der Meer. {ref}`Find out more here <finite_element_method_credit>`.
 ```
 % END-CREDIT

--- a/book/fem/weak.md
+++ b/book/fem/weak.md
@@ -121,3 +121,11 @@ The boundary condition $EA\frac{\partial u}{\partial x}=F$ at $x=L$ involves eva
 [^BC_types]: We can also find Robin type of boundary conditions, which are a mix between Dirichlet and Neumann type, for example: $\alpha u + EA \frac{\partial u}{\partial x}=F$.
 
 [^weak_bc]: We can also enforce Dirichlet boundary conditions in a *weak* sense, by introducing additional terms on the weak form that penalize the difference between the solution and the prescribed value at the boundary. This will not be covered in this chapter.
+
+% START-CREDIT
+% source: finite_element_method
+```{attributiongrey} Attribution
+:class: attribution
+This chapter uses CC BY content written by Oriol Colomés, Iuri Rocha, Frans van der Meer and Martin Lesueur. {fa}`quote-left`{ref}`Find out more here <finite_element_method_credit>`.
+```
+% END-CREDIT

--- a/book/fvm/advection_1.ipynb
+++ b/book/fvm/advection_1.ipynb
@@ -443,7 +443,15 @@
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": []
+      "source": [
+        "% START-CREDIT\n",
+        "% source: finite_volume_method\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. {fa}`quote-left`{ref}`Find out more here <finite_volume_method_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/fvm/advection_1.ipynb
+++ b/book/fvm/advection_1.ipynb
@@ -448,7 +448,7 @@
         "% source: finite_volume_method\n",
         "```{attributiongrey} Attribution\n",
         ":class: attribution\n",
-        "This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. {fa}`quote-left`{ref}`Find out more here <finite_volume_method_credit>`.\n",
+        "This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. `{ref}`Find out more here <finite_volume_method_credit>`.\n",
         "```\n",
         "% END-CREDIT"
       ]

--- a/book/fvm/fvm.ipynb
+++ b/book/fvm/fvm.ipynb
@@ -216,7 +216,7 @@
         "% source: finite_volume_method\n",
         "```{attributiongrey} Attribution\n",
         ":class: attribution\n",
-        "This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. {fa}`quote-left`{ref}`Find out more here <finite_volume_method_credit>`.\n",
+        "This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. {ref}`Find out more here <finite_volume_method_credit>`.\n",
         "```\n",
         "% END-CREDIT"
       ]

--- a/book/fvm/fvm.ipynb
+++ b/book/fvm/fvm.ipynb
@@ -211,14 +211,15 @@
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": []
+      "source": [
+        "% START-CREDIT\n",
+        "% source: finite_volume_method\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. {fa}`quote-left`{ref}`Find out more here <finite_volume_method_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/fvm/getting_started_new.ipynb
+++ b/book/fvm/getting_started_new.ipynb
@@ -269,7 +269,15 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
+   "source": [
+    "% START-CREDIT\n",
+    "% source: finite_volume_method\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. {fa}`quote-left`{ref}`Find out more here <finite_volume_method_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/fvm/getting_started_new.ipynb
+++ b/book/fvm/getting_started_new.ipynb
@@ -274,7 +274,7 @@
     "% source: finite_volume_method\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. {fa}`quote-left`{ref}`Find out more here <finite_volume_method_credit>`.\n",
+    "This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. {ref}`Find out more here <finite_volume_method_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/fvm/intro.md
+++ b/book/fvm/intro.md
@@ -1,6 +1,14 @@
 (fvm)=
 # PDEs and the Finite Volume Method
 
+% START-CREDIT
+% source: finite_volume_method
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. {fa}`quote-left`{ref}`Find out more here <finite_volume_method_credit>`.
+```
+% END-CREDIT
+
 The Finite Volume Method (FVM) is a numerical approach for solving partial differential equations (PDEs); it builds on many of the concepts covered by the Finite Difference Method (FDM), covered earlier in this textbook. The method evaluates a quantity of interest in space and time, $\phi(\mathbf{x},t)$, over a domain of interest, $\Omega$.  One main advantage of the finite volume method is that it is well-suited to flow-based problems (e.g., computational fluid dynamics), but it is also a relatively simple method that can be applied to a wide variety of physics-based conservation laws (e.g., mass, momentum and energy). 
 
 The general scheme for FV problems is as follows:

--- a/book/fvm/intro.md
+++ b/book/fvm/intro.md
@@ -5,7 +5,7 @@
 % source: finite_volume_method
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. {fa}`quote-left`{ref}`Find out more here <finite_volume_method_credit>`.
+This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. {ref}`Find out more here <finite_volume_method_credit>`.
 ```
 % END-CREDIT
 

--- a/book/fvm/unstructured_meshes.ipynb
+++ b/book/fvm/unstructured_meshes.ipynb
@@ -131,7 +131,15 @@
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": []
+      "source": [
+        "% START-CREDIT\n",
+        "% source: finite_volume_method\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. {fa}`quote-left`{ref}`Find out more here <finite_volume_method_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/fvm/unstructured_meshes.ipynb
+++ b/book/fvm/unstructured_meshes.ipynb
@@ -136,7 +136,7 @@
         "% source: finite_volume_method\n",
         "```{attributiongrey} Attribution\n",
         ":class: attribution\n",
-        "This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. {fa}`quote-left`{ref}`Find out more here <finite_volume_method_credit>`.\n",
+        "This chapter is written by Robert Lanzafame and Jaime Arriaga Garcia. {ref}`Find out more here <finite_volume_method_credit>`.\n",
         "```\n",
         "% END-CREDIT"
       ]

--- a/book/ml/decision_theory_interactive.ipynb
+++ b/book/ml/decision_theory_interactive.ipynb
@@ -465,6 +465,20 @@
         "\n",
         "So far, we have looked at our k-nearest neighbors regressor, which is relatively easy to understand and play around with. However, this method is not often used in practice, as it scales poorly for large datasets. Furthermore, computing the closest points becomes computationally expensive when considering multiple inputs (high dimensions). In a limited data setting, taking the average of the nearest neighbors will often lead to poor performance. k-nearest neighbors is also sensitive to outliers. In the following chapter, we will apply what we have learned to a different model, namely, linear regression."
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ebcbde7a",
+      "metadata": {},
+      "source": [
+        "% START-CREDIT\n",
+        "% source: machine_learning\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/ml/decision_theory_interactive.ipynb
+++ b/book/ml/decision_theory_interactive.ipynb
@@ -475,7 +475,7 @@
         "% source: machine_learning\n",
         "```{attributiongrey} Attribution\n",
         ":class: attribution\n",
-        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {ref}`Find out more here <machine_learning_credit>`.\n",
         "```\n",
         "% END-CREDIT"
       ]

--- a/book/ml/knn_interactive.ipynb
+++ b/book/ml/knn_interactive.ipynb
@@ -385,7 +385,7 @@
         "% source: machine_learning\n",
         "```{attributiongrey} Attribution\n",
         ":class: attribution\n",
-        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {ref}`Find out more here <machine_learning_credit>`.\n",
         "```\n",
         "% END-CREDIT"
       ]

--- a/book/ml/knn_interactive.ipynb
+++ b/book/ml/knn_interactive.ipynb
@@ -375,6 +375,20 @@
         "## Final remarks\n",
         "So far, we have looked at our k-nearest neighbors regressor mostly qualitatively. However, it is possible to apply a more quantitative framework to our model and find the optimal value for $k$ in a more structured way. The following video and accompanying chapter will discuss how this is done. See you there!"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "dd7bfdc2",
+      "metadata": {},
+      "source": [
+        "% START-CREDIT\n",
+        "% source: machine_learning\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/ml/linear_models_interactive.ipynb
+++ b/book/ml/linear_models_interactive.ipynb
@@ -1331,9 +1331,17 @@
     },
     {
       "cell_type": "markdown",
-      "id": "4dc7cf29",
+      "id": "09613782",
       "metadata": {},
-      "source": []
+      "source": [
+        "% START-CREDIT\n",
+        "% source: machine_learning\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/ml/linear_models_interactive.ipynb
+++ b/book/ml/linear_models_interactive.ipynb
@@ -1338,7 +1338,7 @@
         "% source: machine_learning\n",
         "```{attributiongrey} Attribution\n",
         ":class: attribution\n",
-        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {ref}`Find out more here <machine_learning_credit>`.\n",
         "```\n",
         "% END-CREDIT"
       ]

--- a/book/ml/mude_tools.py
+++ b/book/ml/mude_tools.py
@@ -1,3 +1,13 @@
+# START-CREDIT
+# source: machine_learning
+#
+# This file is released under the license for the MUDE Book:
+#   https://github.com/TUDelft-MUDE/book
+# Authors: Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
+#
+# See the Credits section of the book additional information.
+# END-CREDIT
+
 # Import necessary packages
 import numpy as np
 import matplotlib.pyplot as plt

--- a/book/ml/mude_tools.py
+++ b/book/ml/mude_tools.py
@@ -1,11 +1,13 @@
 # START-CREDIT
 # source: machine_learning
 #
-# This file is released under the license for the MUDE Book:
-#   https://github.com/TUDelft-MUDE/book
-# Authors: Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
+# This file is from the 2024 edition of the MUDE Textbook, released
+# with a CC BY License. See the Credits section for more information:
+# https://mude.citg.tudelft.nl/2024/book/credits
 #
-# See the Credits section of the book additional information.
+# Authors: Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
+# Copyright: Delft University of Technology.
+#
 # END-CREDIT
 
 # Import necessary packages

--- a/book/ml/nn_interactive.ipynb
+++ b/book/ml/nn_interactive.ipynb
@@ -631,7 +631,7 @@
         "% source: machine_learning\n",
         "```{attributiongrey} Attribution\n",
         ":class: attribution\n",
-        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {ref}`Find out more here <machine_learning_credit>`.\n",
         "```\n",
         "% END-CREDIT"
       ]

--- a/book/ml/nn_interactive.ipynb
+++ b/book/ml/nn_interactive.ipynb
@@ -621,6 +621,20 @@
         "\n",
         "In these videos you have seen a non-parametric model, namely k-nearest neighbours, and have learned about the bias-variance trade-off. Linear regression was shown as a parametric model that is linear in its parameters and has a closed form solution. Ridge regression has been introduced to prevent overfitting. Stochastic gradient descent has been shown as a way to train a model in an iterative fashion. In this final chapter, we explored a model with a nonlinear dependence on its parameters. You now understand the underlying principles of a broad set machine learning techniques, and know how to distinguish naive curve fitting from extracting (or learning) the relevant trends and patterns in data."
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "adec1f79",
+      "metadata": {},
+      "source": [
+        "% START-CREDIT\n",
+        "% source: machine_learning\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/ml/overview.md
+++ b/book/ml/overview.md
@@ -1,4 +1,13 @@
+(machine_learning)=
 # Introduction to Machine Learning
+
+% START-CREDIT
+% source: machine_learning
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.
+```
+% END-CREDIT
 
 _Machine learning_ is a set of techniques that uses computer algorithms to fit the parameters of a model. In the context of MUDE, it is a set of data-driven modelling techniques, closely related to the methods used in observation theory. However, whereas in observation theory we constructed the design matrix ourselves, based on some physics-based knowledge of the system of interest, in machine learning applications, we allow the algorithm more freedom to build (and refine) the model. Although this comes at the cost of less control over model parameters (the "unknowns" from observation theory) and increased complexity, the benefit is a more flexible model that is capable of capturing key characteristics of the problem at hand. For example, a neural network can be defined using thousands of weights (model parameters); far more than we can create with more "hands-on" techniques!
 

--- a/book/ml/overview.md
+++ b/book/ml/overview.md
@@ -5,7 +5,7 @@
 % source: machine_learning
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.
+This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {ref}`Find out more here <machine_learning_credit>`.
 ```
 % END-CREDIT
 

--- a/book/ml/review.ipynb
+++ b/book/ml/review.ipynb
@@ -45,7 +45,7 @@
     "% source: machine_learning\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+    "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {ref}`Find out more here <machine_learning_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/ml/review.ipynb
+++ b/book/ml/review.ipynb
@@ -35,6 +35,20 @@
     "````\n",
     "`````"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bf8722e",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: machine_learning\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/ml/ridge_sgd_interactive.ipynb
+++ b/book/ml/ridge_sgd_interactive.ipynb
@@ -381,6 +381,20 @@
       "metadata": {},
       "outputs": [],
       "source": []
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d66a05ba",
+      "metadata": {},
+      "source": [
+        "% START-CREDIT\n",
+        "% source: machine_learning\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/ml/ridge_sgd_interactive.ipynb
+++ b/book/ml/ridge_sgd_interactive.ipynb
@@ -391,7 +391,7 @@
         "% source: machine_learning\n",
         "```{attributiongrey} Attribution\n",
         ":class: attribution\n",
-        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {ref}`Find out more here <machine_learning_credit>`.\n",
         "```\n",
         "% END-CREDIT"
       ]

--- a/book/ml/teach_interactive.ipynb
+++ b/book/ml/teach_interactive.ipynb
@@ -289,7 +289,7 @@
     "% source: machine_learning\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+    "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {ref}`Find out more here <machine_learning_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/ml/teach_interactive.ipynb
+++ b/book/ml/teach_interactive.ipynb
@@ -279,6 +279,20 @@
    "source": [
     "plot3 = get_plot3()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e03119e4",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: machine_learning\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/modelling/classification.md
+++ b/book/modelling/classification.md
@@ -19,7 +19,7 @@ Once we are sure that the model can reproduce the behaviors we are interested in
 
 ***
 
-Using a short practical example to illustrate this: imagine you are throwing a projectile, let us say it is a basket ball, and you want to **model** its trajectory. To do so, you would write the following equations of motion:
+Using a short practical example to illustrate this: imagine you are throwing a projectile, let us say it is a basket ball, and you want to **model** its trajectory. To do so, you would write the following equations of motion of the ball in the $x$ and $y$ direction, and obtain the following the kinematic expressions that entirely define the trajectory of the ball::
 
 $$\begin{cases}x=v_0t\cos\theta \\ y=v_0t\sin\theta-\frac{1}{2}gt^2\end{cases}$$
 
@@ -88,9 +88,9 @@ In the case of both these examples, it is advisable to build the model in a diff
 
 Models can be classified in different ways. Here, we are going to introduce the classification according to their nature. There are four categories:
 
-* **Conceptual models**: representations of how reality looks at the highest level of abstraction. These are the least interesting ones in our course, so we will not go much more in-depth in them. 
-* **Mechanistic models**: these models make use of first principle laws from physics, chemistry or biology to describe the behavior of the constitutive elements of the system. They are then systems of systems and can be very complex.
-* **Phenomenological models**: these models rely on the mathematical consistency between quantities based on observations. This is, you take measurements during experiments, you have a look at them under the view of the existing first principles of physics and infer how they are related to each other. Therefore, they do not only rely on data but also they have to be mathematically sound.
+* **Conceptual models**: representations of how reality looks at the highest level of abstraction. This should be always the first step of any modelling approach, and abstracting a real-case scenario is not always straightforward. In our case, we will generally provide such abstractions directly, so we will not go much more in-depth into this topic here.
+* **Mechanistic models**: these models make use of first principle laws from physics, chemistry or biology to describe the behavior of the constitutive elements of the system. They are then systems of mechanistic models which can be very complex.
+* **Phenomenological models**: these models rely on the mathematical consistency between quantities based on observations. This is, you take measurements during experiments, you have a look at them under the view of the existing first principles of physics and infer how they are related to each other. Therefore, they do not only rely on data but also they have to be mathematically sound and should obey the basic laws of mechanics and thermodynamics to the extent possible. Phenomenological models are often only valid for a very specific scale (e.g. micro-scale or macro-scale), depending on the type of experimental data used to derive them, and usually cannot be upscaled or downscaled.
 * **Data-driven models**: these models, as the name indicated, make only use of data. Thus, you perform experiments, measure several variables and perform some sort of data analysis, such as regression, to figure out the relationship between input and outputs. 
 
 Let's see the last three with some examples.

--- a/book/modelling/classification.md
+++ b/book/modelling/classification.md
@@ -129,3 +129,10 @@ Imagine we want to predict the force of waves acting on a wall. To do so, we sta
 
 This is purely empirical and, thus, a data-driven model! We have simply used data to fit a relationship **input -> output**. These models can be very useful when trying to model very complex systems when there is lots of data available.
 
+% START-CREDIT
+% source: modelling_concepts
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Alessandro Cabboi, Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <modelling_concepts_credit>`.
+```
+% END-CREDIT

--- a/book/modelling/decisions.md
+++ b/book/modelling/decisions.md
@@ -90,3 +90,11 @@ Note that there are also uncertainties regarding the measurement of the observat
 **Cases of deterministic systems:**
 
 Known structures subject to known static or dynamic loads. For instance, when we decide to model the response of a building (deformations) under a specific (known) load. Note, however, that in practice loads are almost always variable, or impossible to predict with certainty; thus we will often use deterministic models to understand the behavior of the structure of interest, while also using a stochastic models to check whether the structure will perform well under the range of loads that can be expected.
+
+% START-CREDIT
+% source: modelling_concepts
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Alessandro Cabboi, Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <modelling_concepts_credit>`.
+```
+% END-CREDIT

--- a/book/modelling/decisions.md
+++ b/book/modelling/decisions.md
@@ -2,7 +2,7 @@
 
 In this section, we are going to focus on the decisions we make when setting up a model. We will start seeing models as part of the creative and decision making process!
 
-When building a model, we need to identify which simplifications we can make to keep our model as simple as possible, while modelling the system we are interested in with the appropriate accuracy. In real-life applications, simpler models also equates to lower costs, so it is often one of the main considerations in model design. In short, the simpler, the better, as long as it answers our questions. We are going to talk about the following chaaracteristics of a model:
+When building a model, we need to identify which simplifications we can make to keep our model as simple as possible, while modelling the system we are interested in with the appropriate accuracy. In real-life applications, simpler models also equates to lower costs, so it is often one of the main considerations in model design. In short, the simpler, the better, as long as it answers our questions. We are going to talk about the following characteristics of a model:
 
 - Dynamic vs. static models
 - Linear vs. non-linear models
@@ -89,6 +89,4 @@ Note that there are also uncertainties regarding the measurement of the observat
 
 **Cases of deterministic systems:**
 
-Known structures subject to known static or dynamic loads. For instance, when we decide to model the response of a building (deformations) under a certain wind load.
-
-
+Known structures subject to known static or dynamic loads. For instance, when we decide to model the response of a building (deformations) under a specific (known) load. Note, however, that in practice loads are almost always variable, or impossible to predict with certainty; thus we will often use deterministic models to understand the behavior of the structure of interest, while also using a stochastic models to check whether the structure will perform well under the range of loads that can be expected.

--- a/book/modelling/gof.md
+++ b/book/modelling/gof.md
@@ -92,3 +92,11 @@ If we compute this metric for our example, we obtain $rbias(H_{m0})=0.05$ and $r
 
 
 [^reference]: Data extracted from Mares-Nasarre et al. (2022). Hydraulic stability of cube-armored mound breakwaters in depth-limited breaking wave conditions, *Ocean Engineering* 259, 111845.  https://doi.org/10.1016/j.oceaneng.2022.111845
+
+% START-CREDIT
+% source: modelling_concepts
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Alessandro Cabboi, Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <modelling_concepts_credit>`.
+```
+% END-CREDIT

--- a/book/modelling/overview.md
+++ b/book/modelling/overview.md
@@ -1,4 +1,13 @@
+(modelling_concepts)=
 # Modelling concepts
+
+% START-CREDIT
+% source: modelling_concepts
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Alessandro Cabboi, Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <modelling_concepts_credit>`.
+```
+% END-CREDIT
 
 In this chapter, you will be introduced to the basic concepts related to modelling. The chapter is split into four sections, with the aim of each to enable you to discuss and answer the following questions, respectively:
 - What is a model and which types of models can be built?

--- a/book/modelling/temporary.md
+++ b/book/modelling/temporary.md
@@ -21,3 +21,11 @@ Yet to do:
 - Slides: https://mude.citg.tudelft.nl/archive-2022/_downloads/24f6b220ea452bc28ed0ebc514456f10/1-4-calibration-slides.pdf
 
 Quiz: https://mude.citg.tudelft.nl/archive-2022/week-1-4/1-3-brightspace-quiz.html
+
+% START-CREDIT
+% source: modelling_concepts
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Alessandro Cabboi, Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <modelling_concepts_credit>`.
+```
+% END-CREDIT

--- a/book/modelling/validate_verify.md
+++ b/book/modelling/validate_verify.md
@@ -112,3 +112,11 @@ Be very systematic in verifying and validating models:
 * Keep note of what changed in the results, for each modification performed in
 the model;
 * Clearly highlight for which parameter space the model is valid.
+
+% START-CREDIT
+% source: modelling_concepts
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Alessandro Cabboi, Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <modelling_concepts_credit>`.
+```
+% END-CREDIT

--- a/book/multivariate/design.md
+++ b/book/multivariate/design.md
@@ -59,3 +59,11 @@ The following pages work through an example related to flooding on a river to il
 %3. Illustrate the effect of various marginal distributions and dependence models on the results through examples and exercises.
 
 [^conundrum]: a confusing and difficult problem or question (source: Oxford Languages, via Google).
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/multivariate/design/one-random-variable.md
+++ b/book/multivariate/design/one-random-variable.md
@@ -1,6 +1,14 @@
 (prob_design_1_rv)=
 # One Random Variable
 
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This page reuses material from another book. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT
+
 % MMMMM: this page is from 2023 book and has been modified for the 2024 book. Sometime in between this page was also added to the risk and reliability book, which has _not_ been kept in sync.
 
 Consider a river that is protected by dikes: earthen embankments with the purpose of keeping water in the river channel and preventing flooding of the hinterland. The dikes should be designed and built such that the height allows the river to safely pass the maximum discharge every year, measured in m$^3$/s. A rating curve ({numref}`rating_curve`) gives us the relationship between discharge and water depth, $H_w$, so if we know what the maximum discharge is, we can build our dikes to the critical height, $h_{dike}\geq H_w$. But there is a problem---what is the maximum discharge in the river each year? How would we even go about determining this value? One way is to make observations and find the highest recorded data point.

--- a/book/multivariate/design/two-random-variables.md
+++ b/book/multivariate/design/two-random-variables.md
@@ -1,6 +1,14 @@
 (prob_design_2_rv)=
 # Two Random Variables
 
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This page reuses material from another book. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT
+
 % MMMMM: this page is from 2023 book and has been modified for the 2024 book. Sometime in between this page was also added to the risk and reliability book, which has _not_ been kept in sync.
 
 The previous section illustrated how a decision for dike height, $h_{dike}$, can take into account uncertainty in river discharge. We used a maximum allowable probability of flooding to derive the specific value of discharge, $q_{design}$, that should be used to choose $h_{dike}$. This was necessary because there was otherwise no way of establishing what the maximum discharge should be. The only variable considered to be random was the maximum river discharge that occurs each year. This section considers how the design process becomes more complicated when *two* random variables are considered (two load variables).

--- a/book/multivariate/events.md
+++ b/book/multivariate/events.md
@@ -148,5 +148,10 @@ where $B_i$ are a set of _mutually exclusive_ and _collectively exhaustive_ even
 
 If you need further refresher of these concepts, you can further read and practice [here](https://teachbooks.github.io/learn-probability/section_01/Total_Probability_Theorem.html).
 
-
-
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/multivariate/gaussian.md
+++ b/book/multivariate/gaussian.md
@@ -48,6 +48,14 @@ Also, you can plan with the interactive element below changing the correlation v
 
 <iframe src="../_static/elements/element_correlation.html" width="600" height="400" frameborder="0"></iframe>
 
+% START-CREDIT
+% source: maxramgraber
+```{attributiongrey} Attribution
+:class: attribution
+This interactive figure is created by Max Ramgraber. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT
+
 ## Conditionalizing a bivariate Gaussian distribution
 
 Multivariate Gaussian distributions are useful because we can derive results analytically. Here, we are going to conditionalize a bivariate Gaussian distribution to exemplify it.
@@ -160,3 +168,11 @@ If you need to refresh the concept of covariance and correlation and want to see
 ```
 
 [^note]: You already studied covariance matrices [here](correl).
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/multivariate/gaussian.md
+++ b/book/multivariate/gaussian.md
@@ -46,15 +46,21 @@ Bivariate Gaussian distribution: (left) probability density function, and (right
 
 Also, you can plan with the interactive element below changing the correlation value yourself. Observe how the distribution's _density_ contours, or a scatter plot of _samples,_ change when you adjust the correlation.
 
-<iframe src="../_static/elements/element_correlation.html" width="600" height="400" frameborder="0"></iframe>
-
 % START-CREDIT
 % source: maxramgraber
+````{margin}
 ```{attributiongrey} Attribution
 :class: attribution
 This interactive figure is created by Max Ramgraber. {ref}`Find out more here <distributions_credit>`.
 ```
+````
 % END-CREDIT
+
+````{iframe-figure} ../_static/elements/element_correlation.html
+:name: density_scatter_2
+
+Interactively change the correlation coefficient to visualize the effect on density contours or samples of the bivariate Gaussian distribution.
+````
 
 ## Conditionalizing a bivariate Gaussian distribution
 

--- a/book/multivariate/nongaussian.md
+++ b/book/multivariate/nongaussian.md
@@ -81,3 +81,11 @@ You will be provided Python code to evaluate multivariate distributions construc
 If you want to learn more about bivariate copulas and other multivariate joint distributions in higher dimensions, you can study them in the Cross Over "MORE: Probabilistic Modelling of real-world phenomena through ObseRvations and Elicitation".
 
 ```
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/multivariate/overview.md
+++ b/book/multivariate/overview.md
@@ -26,15 +26,21 @@ $$
 
 where $X_1$ and $X_2$ are random variables, $Cov(X_1,X_2)$ is their covariance, and $\sigma_{X_1}$ and $\sigma_{X_2}$ are the standard deviations of $X_1$ and $X_2$. $-1 \leq \rho(X_1,X_2) \leq 1$, being $\rho(X_1,X_2)=-1$ a perfect negative linear correlation, and $\rho(X_1,X_2)=1$ a perfect positive linear correlation. If $X_1$ and $X_2$ are independent, then $\rho(X_1,X_2) \to 0$[^note]. This is, that having information about $X_1$ does not provide us with information about $X_2$. The interactive element below allows you to play around with the correlation value yourself. Observe how the distribution's _density_ contours, or a scatter plot of _samples,_ change when you adjust the correlation.
 
-<iframe src="../_static/elements/element_correlation.html" width="600" height="400" frameborder="0"></iframe>
-
 % START-CREDIT
 % source: maxramgraber
+````{margin}
 ```{attributiongrey} Attribution
 :class: attribution
 This interactive figure is created by Max Ramgraber. {ref}`Find out more here <distributions_credit>`.
 ```
+````
 % END-CREDIT
+
+````{iframe-figure} ../_static/elements/element_correlation.html
+:name: density_scatter
+
+Interactively change the correlation coefficient to visualize the effect on density contours or samples of the bivariate Gaussian distribution.
+````
 
 **Overview of this Chapter**
 

--- a/book/multivariate/overview.md
+++ b/book/multivariate/overview.md
@@ -1,6 +1,14 @@
 
-(mulitivar)=
+(mult_dist)=
 # Multivariate Distributions
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT
 
 Challenges in all branches of science and engineering involve working in situations where uncertainty plays a significant role: prior chapters of this book focused a lot on _error_, but often we must also deal with data scarce scenarios (often categorized as _epistemic_ uncertainty) and natural phenomena with a significant _stochastic_ nature (often categorized as _aleatoric_ uncertainty). As seen in the previous chapter, univariate continuous distributions can assist us in modelling uncertainty associated with a specific variable in order to quantitatively account for uncertainty in general; the distribution helps inform the decision-making process or risk analysis. However, our problems of interest are typically complex and usually involve more than one variable: a _multivariate_ situation.
 
@@ -19,6 +27,14 @@ $$
 where $X_1$ and $X_2$ are random variables, $Cov(X_1,X_2)$ is their covariance, and $\sigma_{X_1}$ and $\sigma_{X_2}$ are the standard deviations of $X_1$ and $X_2$. $-1 \leq \rho(X_1,X_2) \leq 1$, being $\rho(X_1,X_2)=-1$ a perfect negative linear correlation, and $\rho(X_1,X_2)=1$ a perfect positive linear correlation. If $X_1$ and $X_2$ are independent, then $\rho(X_1,X_2) \to 0$[^note]. This is, that having information about $X_1$ does not provide us with information about $X_2$. The interactive element below allows you to play around with the correlation value yourself. Observe how the distribution's _density_ contours, or a scatter plot of _samples,_ change when you adjust the correlation.
 
 <iframe src="../_static/elements/element_correlation.html" width="600" height="400" frameborder="0"></iframe>
+
+% START-CREDIT
+% source: maxramgraber
+```{attributiongrey} Attribution
+:class: attribution
+This interactive figure is created by Max Ramgraber. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT
 
 **Overview of this Chapter**
 

--- a/book/multivariate/variables.md
+++ b/book/multivariate/variables.md
@@ -648,3 +648,11 @@ The large difference between both probabilities, illustrates the role of depende
 As we have seen in the preceding examples, dependence can have a significant role in the computation of probabilities. In particular, the examples illustrate very clearly that we should no longer be satisfied with the simplifying assumption of independence, and that for many problems $P(A\;\cap\;B)\neq P(A)P(B)$. But how can we compute it?
 
 The following pages will explore methods to describe dependence quantitatively for continuous random variables.
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/numerical_methods/1-revision-of-concepts.ipynb
+++ b/book/numerical_methods/1-revision-of-concepts.ipynb
@@ -249,7 +249,7 @@
     "% source: numerical_modelling\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {ref}`Find out more here <numerical_modelling_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/numerical_methods/1-revision-of-concepts.ipynb
+++ b/book/numerical_methods/1-revision-of-concepts.ipynb
@@ -240,6 +240,19 @@
    "source": [
     "This algorithm requires the derivative of the function, which is approximated by considering a small interval dx around point x. The result is a significant reduction of the number of computations needed to get a solution that is also more accurate than the first algorithm."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: numerical_modelling\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/numerical_methods/2-derivative.ipynb
+++ b/book/numerical_methods/2-derivative.ipynb
@@ -77,6 +77,19 @@
     "graphs illustrating three different ways to approximate derivatives.\n",
     "```\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: numerical_modelling\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/numerical_methods/2-derivative.ipynb
+++ b/book/numerical_methods/2-derivative.ipynb
@@ -86,7 +86,7 @@
     "% source: numerical_modelling\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {ref}`Find out more here <numerical_modelling_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/numerical_methods/3-fdm-introduction.ipynb
+++ b/book/numerical_methods/3-fdm-introduction.ipynb
@@ -61,15 +61,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c8a39a6",
+   "id": "504db773",
    "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "de3eb792",
-   "metadata": {},
-   "source": []
+   "source": [
+    "% START-CREDIT\n",
+    "% source: numerical_modelling\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/numerical_methods/3-fdm-introduction.ipynb
+++ b/book/numerical_methods/3-fdm-introduction.ipynb
@@ -68,7 +68,7 @@
     "% source: numerical_modelling\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {ref}`Find out more here <numerical_modelling_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/numerical_methods/4-taylor-series-expansion.ipynb
+++ b/book/numerical_methods/4-taylor-series-expansion.ipynb
@@ -468,7 +468,7 @@
     "% source: numerical_modelling\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {ref}`Find out more here <numerical_modelling_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/numerical_methods/4-taylor-series-expansion.ipynb
+++ b/book/numerical_methods/4-taylor-series-expansion.ipynb
@@ -459,6 +459,19 @@
     "```\n",
     ":::"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: numerical_modelling\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/numerical_methods/5-numerical-integration.ipynb
+++ b/book/numerical_methods/5-numerical-integration.ipynb
@@ -516,7 +516,7 @@
         "% source: numerical_modelling\n",
         "```{attributiongrey} Attribution\n",
         ":class: attribution\n",
-        "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+        "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {ref}`Find out more here <numerical_modelling_credit>`.\n",
         "```\n",
         "% END-CREDIT"
       ]

--- a/book/numerical_methods/5-numerical-integration.ipynb
+++ b/book/numerical_methods/5-numerical-integration.ipynb
@@ -137,7 +137,7 @@
         "\\int_{a}^{b} f(x) \\, dx \\approx \\sum_{i=0}^{n-1} \\frac{f(x_{i}) + f(x_{i+1})}{2} \\Delta x\n",
         "$$\n",
         "\n",
-        "### Simpson\u2019s Rule\n",
+        "### Simpson’s Rule\n",
         "\n",
         "\n",
         "\n",
@@ -146,7 +146,7 @@
         "\n",
         "Illustrating the Simpson Rule over interval [a,b]\n",
         "```\n",
-        "Simpson\u2019s rule uses a second order polynomial. It computes the integral of the function $f(x)$ by fitting parabolas needing three consecutive function points and adding the areas under them (see $p_1(x)$ and $p_2(x)$ in the figure). In formula form:\n",
+        "Simpson’s rule uses a second order polynomial. It computes the integral of the function $f(x)$ by fitting parabolas needing three consecutive function points and adding the areas under them (see $p_1(x)$ and $p_2(x)$ in the figure). In formula form:\n",
         "\n",
         "$$\n",
         "\\int_{a}^{b} f(x) \\, dx \\approx \\sum_{i=1}^{n/2} \\frac{f(x_{2i-2}) + 4f(x_{2i-1}) + f(x_{2i})}{6} 2\\Delta x\n",
@@ -511,7 +511,15 @@
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": []
+      "source": [
+        "% START-CREDIT\n",
+        "% source: numerical_modelling\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/numerical_methods/6-initial-value-problem-singlestep.ipynb
+++ b/book/numerical_methods/6-initial-value-problem-singlestep.ipynb
@@ -1030,7 +1030,7 @@
     "% source: numerical_modelling\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {ref}`Find out more here <numerical_modelling_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/numerical_methods/6-initial-value-problem-singlestep.ipynb
+++ b/book/numerical_methods/6-initial-value-problem-singlestep.ipynb
@@ -1023,9 +1023,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e7c3322",
+   "id": "d117d9be",
    "metadata": {},
-   "source": []
+   "source": [
+    "% START-CREDIT\n",
+    "% source: numerical_modelling\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/numerical_methods/7-multistep_and_multistage_methods.ipynb
+++ b/book/numerical_methods/7-multistep_and_multistage_methods.ipynb
@@ -60,9 +60,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bdc9175d",
+   "id": "9a208526",
    "metadata": {},
-   "source": []
+   "source": [
+    "% START-CREDIT\n",
+    "% source: numerical_modelling\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/numerical_methods/7-multistep_and_multistage_methods.ipynb
+++ b/book/numerical_methods/7-multistep_and_multistage_methods.ipynb
@@ -67,7 +67,7 @@
     "% source: numerical_modelling\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {ref}`Find out more here <numerical_modelling_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/numerical_methods/8-boundary-value-problem.ipynb
+++ b/book/numerical_methods/8-boundary-value-problem.ipynb
@@ -547,9 +547,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82ae3207",
+   "id": "8446394c",
    "metadata": {},
-   "source": []
+   "source": [
+    "% START-CREDIT\n",
+    "% source: numerical_modelling\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/numerical_methods/8-boundary-value-problem.ipynb
+++ b/book/numerical_methods/8-boundary-value-problem.ipynb
@@ -554,7 +554,7 @@
     "% source: numerical_modelling\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {ref}`Find out more here <numerical_modelling_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/numerical_methods/9-starting_with_PDEs.ipynb
+++ b/book/numerical_methods/9-starting_with_PDEs.ipynb
@@ -171,6 +171,20 @@
     "\n",
     "\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e66ab01b",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: numerical_modelling\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/numerical_methods/9-starting_with_PDEs.ipynb
+++ b/book/numerical_methods/9-starting_with_PDEs.ipynb
@@ -181,7 +181,7 @@
     "% source: numerical_modelling\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {ref}`Find out more here <numerical_modelling_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/numerical_methods/overview.md
+++ b/book/numerical_methods/overview.md
@@ -5,7 +5,7 @@
 % source: numerical_modelling
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.
+This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {ref}`Find out more here <numerical_modelling_credit>`.
 ```
 % END-CREDIT
 

--- a/book/numerical_methods/overview.md
+++ b/book/numerical_methods/overview.md
@@ -1,4 +1,13 @@
+(numerical_modelling)=
 # Numerical Modelling
+
+% START-CREDIT
+% source: numerical_modelling
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.
+```
+% END-CREDIT
 
 The Finite Difference Method (FDM) is a fundamental numerical approach used to solve differential equations that govern physical phenomena. These phenomena include heat flow through media, the distribution of stresses in solid structures, fluid flow through porous media, pollutant dispersion in the air and water, amongst others. Virtually, any physical phenomena can be tackled by solving numerically differential equations. The FDM provides engineers with the flexibility to model and analyze a complex geometries with varied past, present and future scenarios, optimize designs, ensure safety, reduce costs, and predict failures. Even more! 
 

--- a/book/numerical_methods/taylor-series-exercise.ipynb
+++ b/book/numerical_methods/taylor-series-exercise.ipynb
@@ -398,7 +398,7 @@
     "% source: numerical_modelling\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {ref}`Find out more here <numerical_modelling_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/numerical_methods/taylor-series-exercise.ipynb
+++ b/book/numerical_methods/taylor-series-exercise.ipynb
@@ -389,6 +389,19 @@
    "source": [
     "check_answer(\"eq3_answer\",eq3_correct, check_equation)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: numerical_modelling\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Jaime Arriaga Garcia, Justin Pittman and Robert Lanzafame. {fa}`quote-left`{ref}`Find out more here <numerical_modelling_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/observation_theory/01_Introduction.md
+++ b/book/observation_theory/01_Introduction.md
@@ -187,3 +187,11 @@ Linear regression example for amount of rainfall (independent variable) and rive
 The estimation principles discussed in this part are needed for estimating these relationships.
 
 Supervised machine learning (MUDE topic in Q2) is all about finding relationships between target (dependent) variables and certain features (predictors), and therefore regression analysis.
+
+% START-CREDIT
+% source: observation_theory
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.
+```
+% END-CREDIT

--- a/book/observation_theory/02_LeastSquares.md
+++ b/book/observation_theory/02_LeastSquares.md
@@ -131,3 +131,11 @@ name: LSsol
 ---
 Least-squares fit to a set of 5 observations affected by random errors. Index $i$ refers to the $i$th observation.
 ```
+
+% START-CREDIT
+% source: observation_theory
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.
+```
+% END-CREDIT

--- a/book/observation_theory/02_LeastSquares_NB.ipynb
+++ b/book/observation_theory/02_LeastSquares_NB.ipynb
@@ -421,6 +421,19 @@
    "source": [
     "plot_prediction()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: observation_theory\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/observation_theory/03_Notebook_WLS.ipynb
+++ b/book/observation_theory/03_Notebook_WLS.ipynb
@@ -377,6 +377,19 @@
     "<b>You can play with the weight factor of case 2 and 3 to see how the impact changes, depending on its size.</b>\n",
     ":::"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: observation_theory\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/observation_theory/03_WeightedLSQ.md
+++ b/book/observation_theory/03_WeightedLSQ.md
@@ -114,3 +114,11 @@ On the exam you might be asked for deriving this (i.e., not as multiple choice).
 
 <iframe src="https://tudelft.h5p.com/content/1292060771065957877/embed" aria-label="Quiz_WLS_apply" width="1088" height="637" frameborder="0" allowfullscreen="allowfullscreen" allow="autoplay *; geolocation *; microphone *; camera *; midi *; encrypted-media *"></iframe><script src="https://tudelft.h5p.com/js/h5p-resizer.js" charset="UTF-8"></script>
 :::
+
+% START-CREDIT
+% source: observation_theory
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.
+```
+% END-CREDIT

--- a/book/observation_theory/04_BLUE.md
+++ b/book/observation_theory/04_BLUE.md
@@ -120,3 +120,11 @@ The BLUE estimator is the best (or minimum variance) among all linear unbiased e
 <iframe src="https://tudelft.h5p.com/content/1292062185757789447/embed" aria-label="quiz-RoC_glacier" width="1088" height="637" frameborder="0" allowfullscreen="allowfullscreen" allow="autoplay *; geolocation *; microphone *; camera *; midi *; encrypted-media *"></iframe><script src="https://tudelft.h5p.com/js/h5p-resizer.js" charset="UTF-8"></script>
 
 :::
+
+% START-CREDIT
+% source: observation_theory
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.
+```
+% END-CREDIT

--- a/book/observation_theory/05_Notebook_ConfInt.ipynb
+++ b/book/observation_theory/05_Notebook_ConfInt.ipynb
@@ -412,12 +412,18 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "383836f2",
+   "cell_type": "markdown",
+   "id": "5a3b458c",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "% START-CREDIT\n",
+    "% source: observation_theory\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/observation_theory/05_Precision.md
+++ b/book/observation_theory/05_Precision.md
@@ -140,3 +140,11 @@ Not immediately clear from the expression is that also the redundancy ($=m-n$) i
 <iframe src="https://tudelft.h5p.com/content/1292062157562749767/embed" aria-label="quiz_uniform_motion" width="1088" height="637" frameborder="0" allowfullscreen="allowfullscreen" allow="autoplay *; geolocation *; microphone *; camera *; midi *; encrypted-media *"></iframe><script src="https://tudelft.h5p.com/js/h5p-resizer.js" charset="UTF-8"></script>
 
 :::
+
+% START-CREDIT
+% source: observation_theory
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.
+```
+% END-CREDIT

--- a/book/observation_theory/06_MLE.md
+++ b/book/observation_theory/06_MLE.md
@@ -89,3 +89,10 @@ $$
 
 It follows that the Maximum Likelihood estimator of $\mathrm{x}$ is identical to the BLUE **if** $Y$ is normally distributed.
 
+% START-CREDIT
+% source: observation_theory
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.
+```
+% END-CREDIT

--- a/book/observation_theory/07_NLSQ.md
+++ b/book/observation_theory/07_NLSQ.md
@@ -137,3 +137,11 @@ although this is not strictly true. The estimator $\hat X$ is namely NOT a best 
 However, in practice the linear (first-order Taylor) approximation often works so well that the performance is very close to that of BLUE and we may assume the normal distribution.
 
 As a final note we would like to mention that the Gauss-Newton method is just one approach for solving a non-linear least-squares problem. In practice, especially for highly non-linear problems, the Levenberg-Marquardt method is often used. It can be considered as a refinement of the Gauss-Newton method with a higher chance of convergence.
+
+% START-CREDIT
+% source: observation_theory
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.
+```
+% END-CREDIT

--- a/book/observation_theory/07_Notebook_NLSQ.ipynb
+++ b/book/observation_theory/07_Notebook_NLSQ.ipynb
@@ -140,6 +140,20 @@
     "\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b08d1b5b",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: observation_theory\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/observation_theory/08_Testing.md
+++ b/book/observation_theory/08_Testing.md
@@ -127,3 +127,11 @@ Decision matrix for hypothesis testing.
 <iframe src="https://tudelft.h5p.com/content/1292064948348676677/embed" aria-label="quiz-hypothesis_testing" width="1088" height="637" frameborder="0" allowfullscreen="allowfullscreen" allow="autoplay *; geolocation *; microphone *; camera *; midi *; encrypted-media *"></iframe><script src="https://tudelft.h5p.com/js/h5p-resizer.js" charset="UTF-8"></script>
 
 :::
+
+% START-CREDIT
+% source: observation_theory
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.
+```
+% END-CREDIT

--- a/book/observation_theory/09_Notebook_OMT.ipynb
+++ b/book/observation_theory/09_Notebook_OMT.ipynb
@@ -398,6 +398,19 @@
     "factor = 1\n",
     "plot_results(t, A, y_3, factor * Sigma_Y, conf_level=0.95, alpha = 0.05)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: observation_theory\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/observation_theory/09_Notebook_Testing.ipynb
+++ b/book/observation_theory/09_Notebook_Testing.ipynb
@@ -261,7 +261,15 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
+   "source": [
+    "% START-CREDIT\n",
+    "% source: observation_theory\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/observation_theory/09_Notebook_Testing_download.ipynb
+++ b/book/observation_theory/09_Notebook_Testing_download.ipynb
@@ -248,6 +248,19 @@
     "3. compute the sum of squared residuals $\\hat{\\epsilon}^T \\Sigma_Y^{-1} \\hat{\\epsilon}$ for that model\n",
     "4. apply the GLRT with model 2 as null hypothesis, and your model as alternative hypothesis."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: observation_theory\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/observation_theory/09_TestingSandM.md
+++ b/book/observation_theory/09_TestingSandM.md
@@ -249,3 +249,11 @@ In some cases, you may immediately want to test between two competing models, fo
 2. Apply BLUE for both models
 3. Apply the generalized likelihood ratio test (GLRT)
 4. Present estimates, precision and testing results for accepted model
+
+% START-CREDIT
+% source: observation_theory
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.
+```
+% END-CREDIT

--- a/book/observation_theory/99_NotationFormulas.md
+++ b/book/observation_theory/99_NotationFormulas.md
@@ -72,3 +72,11 @@ This overview with Notation and Formulas will be given on the MUDE exam.
 * - ... covariance matrix 
   - $\Sigma_{\hat{X}} =\mathrm{L^T}\Sigma_Y \mathrm{L} $ 
 ```
+
+% START-CREDIT
+% source: observation_theory
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.
+```
+% END-CREDIT

--- a/book/observation_theory/overview.md
+++ b/book/observation_theory/overview.md
@@ -1,4 +1,12 @@
 (OT)=
 # Observation theory
 
+% START-CREDIT
+% source: observation_theory
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <observation_theory_credit>`.
+```
+% END-CREDIT
+
 As in other physical sciences, empirical data are used in Civil and Environmental Engineering and Applied Earth Sciences to make inferences so as to describe physical reality. Many such problems involve the determination of unknown model parameters that bear a functional relationship to the set of observed data or measurements. This determination or parameter estimation can be based on different estimation principles. 

--- a/book/optimization/Project_GA.ipynb
+++ b/book/optimization/Project_GA.ipynb
@@ -1033,7 +1033,7 @@
     "% source: optimization\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter reuses content Bahman Ahmadi et al. (2024). {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "This chapter reuses content Bahman Ahmadi et al. (2024). {ref}`Find out more here <optimization_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/optimization/Project_GA.ipynb
+++ b/book/optimization/Project_GA.ipynb
@@ -1005,7 +1005,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1023,6 +1023,19 @@
     "# Plot results\n",
     "# To see the values for all the links just turn on the labels in the function below.\n",
     "network_visualization_upgraded (G = G, pos=pos, link_flow=link_flows, capacity_new=capacity ,link_select=links_selected, labels='off')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: optimization\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter reuses content Bahman Ahmadi et al. (2024). {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
    ]
   }
  ],

--- a/book/optimization/Project_MILP.ipynb
+++ b/book/optimization/Project_MILP.ipynb
@@ -3065,6 +3065,19 @@
     "# To see flow and capacity for the entire network\n",
     "network_visualization_upgraded (G = G, pos=pos, link_flow=link_flows, capacity_new=capacity ,link_select=links_selected, labels='on')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: optimization\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter reuses content Bahman Ahmadi et al. (2024). {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/optimization/Project_MILP.ipynb
+++ b/book/optimization/Project_MILP.ipynb
@@ -3074,7 +3074,7 @@
     "% source: optimization\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter reuses content Bahman Ahmadi et al. (2024). {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "This chapter reuses content Bahman Ahmadi et al. (2024). {ref}`Find out more here <optimization_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/optimization/airlines.ipynb
+++ b/book/optimization/airlines.ipynb
@@ -1625,6 +1625,20 @@
     "\n",
     "As you saw above, computation time of solving the model changed when we changed decision variable types from continuous to integer. On the other hand, computation time usually increases with problem size. Try to change the size of this problem (simply by changing the number of months to include in input cell 5 from 6 to a different number and rerunning the code), solve both continuous and integer variations, and record computation times. You can go all the way up to 240 months (but note that this might take quite some time). Make a figure to see the trends properly (e.g., number of months on the x-axis, computation time on the y-axis, and a separate line for each problem variation). What can you conclude?"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2930f32",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: optimization\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/optimization/airlines.ipynb
+++ b/book/optimization/airlines.ipynb
@@ -1635,7 +1635,7 @@
     "% source: optimization\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/optimization/airlines_performance.ipynb
+++ b/book/optimization/airlines_performance.ipynb
@@ -452,7 +452,7 @@
     "% source: optimization\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/optimization/airlines_performance.ipynb
+++ b/book/optimization/airlines_performance.ipynb
@@ -443,6 +443,19 @@
     "\n",
     "Run the functions above with different parameter values and make some figures showing how data processing, model construction and computation time (for different algorithms) grow with the number of periods."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: optimization\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/optimization/airlines_performance_stripped.ipynb
+++ b/book/optimization/airlines_performance_stripped.ipynb
@@ -419,6 +419,34 @@
     "\n",
     "Run the functions above with different parameter values and make some figures showing how data processing, model construction and computation time (for different algorithms) grow with the number of periods."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**End of notebook.**\n",
+    "\n",
+    "<div style=\"margin-top: 50px; padding-top: 20px; border-top: 1px solid #ccc;\">\n",
+    "  <div style=\"display: flex; justify-content: flex-end; gap: 20px; align-items: center;\">\n",
+    "    <a rel=\"MUDE\" href=\"http://mude.citg.tudelft.nl/\">\n",
+    "      <img alt=\"MUDE\" style=\"width:100px; height:auto;\" src=\"https://gitlab.tudelft.nl/mude/public/-/raw/main/mude-logo/MUDE_Logo-small.png\" />\n",
+    "    </a>\n",
+    "    <a rel=\"TU Delft\" href=\"https://www.tudelft.nl/en/ceg\">\n",
+    "      <img alt=\"TU Delft\" style=\"width:100px; height:auto;\" src=\"https://gitlab.tudelft.nl/mude/public/-/raw/main/tu-logo/TU_P1_full-color.png\" />\n",
+    "    </a>\n",
+    "    <a rel=\"license\" href=\"http://creativecommons.org/licenses/by/4.0/\">\n",
+    "      <img alt=\"Creative Commons License\" style=\"width:88px; height:auto;\" src=\"https://i.creativecommons.org/l/by/4.0/88x31.png\" />\n",
+    "    </a>\n",
+    "  </div>\n",
+    "  <div style=\"font-size: 75%; margin-top: 10px; text-align: right;\">\n",
+    "    This file is from the <a rel=\"2024 Textbook\" href=\"http://mude.citg.tudelft.nl/2024/book\">2024 edition of the MUDE Textbook</a>. \n",
+    "  </div>\n",
+    "  <div style=\"font-size: 75%; margin-top: 10px; text-align: right;\">\n",
+    "    &copy; Copyright 2024 TU Delft, <a rel=\"license\" href=\"http://creativecommons.org/licenses/by/4.0/\">CC BY 4.0 License</a>.\n",
+    "  </div>\n",
+    "</div>\n",
+    "<p hidden>% CREDIT-NOTE source: optimization</p>"
+   ]
   }
  ],
  "metadata": {

--- a/book/optimization/airlines_stripped.ipynb
+++ b/book/optimization/airlines_stripped.ipynb
@@ -1601,7 +1601,7 @@
     "% source: optimization\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/optimization/airlines_stripped.ipynb
+++ b/book/optimization/airlines_stripped.ipynb
@@ -1591,6 +1591,20 @@
     "\n",
     "As you saw above, computation time of solving the model changed when we changed decision variable types from continuous to integer. On the other hand, computation time usually increases with problem size. Try to change the size of this problem (simply by changing the number of months to include in input cell 5 from 6 to a different number and rerunning the code), solve both continuous and integer variations, and record computation times. You can go all the way up to 240 months (but note that this might take quite some time). Make a figure to see the trends properly (e.g., number of months on the x-axis, computation time on the y-axis, and a separate line for each problem variation). What can you conclude?"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f502d33f",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: optimization\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/optimization/airplane_exercise.md
+++ b/book/optimization/airplane_exercise.md
@@ -224,6 +224,6 @@ Distribution airplane problem challenge 3
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT

--- a/book/optimization/airplane_exercise.md
+++ b/book/optimization/airplane_exercise.md
@@ -219,3 +219,11 @@ height: 300px
 Distribution airplane problem challenge 3
 ```
 ````
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT

--- a/book/optimization/airplane_original.ipynb
+++ b/book/optimization/airplane_original.ipynb
@@ -229,6 +229,19 @@
     "# Solve\n",
     "model.optimize()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: optimization\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/optimization/airplane_original.ipynb
+++ b/book/optimization/airplane_original.ipynb
@@ -238,7 +238,7 @@
     "% source: optimization\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/optimization/airplane_original_stripped.ipynb
+++ b/book/optimization/airplane_original_stripped.ipynb
@@ -205,6 +205,34 @@
     "# Solve\n",
     "model.optimize()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**End of notebook.**\n",
+    "\n",
+    "<div style=\"margin-top: 50px; padding-top: 20px; border-top: 1px solid #ccc;\">\n",
+    "  <div style=\"display: flex; justify-content: flex-end; gap: 20px; align-items: center;\">\n",
+    "    <a rel=\"MUDE\" href=\"http://mude.citg.tudelft.nl/\">\n",
+    "      <img alt=\"MUDE\" style=\"width:100px; height:auto;\" src=\"https://gitlab.tudelft.nl/mude/public/-/raw/main/mude-logo/MUDE_Logo-small.png\" />\n",
+    "    </a>\n",
+    "    <a rel=\"TU Delft\" href=\"https://www.tudelft.nl/en/ceg\">\n",
+    "      <img alt=\"TU Delft\" style=\"width:100px; height:auto;\" src=\"https://gitlab.tudelft.nl/mude/public/-/raw/main/tu-logo/TU_P1_full-color.png\" />\n",
+    "    </a>\n",
+    "    <a rel=\"license\" href=\"http://creativecommons.org/licenses/by/4.0/\">\n",
+    "      <img alt=\"Creative Commons License\" style=\"width:88px; height:auto;\" src=\"https://i.creativecommons.org/l/by/4.0/88x31.png\" />\n",
+    "    </a>\n",
+    "  </div>\n",
+    "  <div style=\"font-size: 75%; margin-top: 10px; text-align: right;\">\n",
+    "    This file is from the <a rel=\"2024 Textbook\" href=\"http://mude.citg.tudelft.nl/2024/book\">2024 edition of the MUDE Textbook</a>. \n",
+    "  </div>\n",
+    "  <div style=\"font-size: 75%; margin-top: 10px; text-align: right;\">\n",
+    "    &copy; Copyright 2024 TU Delft, <a rel=\"license\" href=\"http://creativecommons.org/licenses/by/4.0/\">CC BY 4.0 License</a>.\n",
+    "  </div>\n",
+    "</div>\n",
+    "<p hidden>% CREDIT-NOTE source: optimization</p>"
+   ]
   }
  ],
  "metadata": {

--- a/book/optimization/augmented_form.md
+++ b/book/optimization/augmented_form.md
@@ -100,3 +100,11 @@ with:
 $$\begin{cases}3x_1-4x'_2+12x_3-s_1 = 300\\ 8x_1-6x'_2-x_4+s_2 = 220\\ 6x_1-5x'_2+3x_3+s_3 = 150\\ x_1,x'_2,x_3,x_4\geq 0\\ s_1,s_2,s_3\geq 0\end{cases}$$
 
 And the problem is transformed in its augmented form and ready to be used in the SIMPLEX method!
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT

--- a/book/optimization/augmented_form.md
+++ b/book/optimization/augmented_form.md
@@ -105,6 +105,6 @@ And the problem is transformed in its augmented form and ready to be used in the
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT

--- a/book/optimization/claysand.ipynb
+++ b/book/optimization/claysand.ipynb
@@ -748,6 +748,19 @@
     "\n",
     "````"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: optimization\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/optimization/claysand.ipynb
+++ b/book/optimization/claysand.ipynb
@@ -757,7 +757,7 @@
     "% source: optimization\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/optimization/claysand_stripped.ipynb
+++ b/book/optimization/claysand_stripped.ipynb
@@ -743,6 +743,34 @@
     "\n",
     "You need to make changes when defining attributes."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**End of notebook.**\n",
+    "\n",
+    "<div style=\"margin-top: 50px; padding-top: 20px; border-top: 1px solid #ccc;\">\n",
+    "  <div style=\"display: flex; justify-content: flex-end; gap: 20px; align-items: center;\">\n",
+    "    <a rel=\"MUDE\" href=\"http://mude.citg.tudelft.nl/\">\n",
+    "      <img alt=\"MUDE\" style=\"width:100px; height:auto;\" src=\"https://gitlab.tudelft.nl/mude/public/-/raw/main/mude-logo/MUDE_Logo-small.png\" />\n",
+    "    </a>\n",
+    "    <a rel=\"TU Delft\" href=\"https://www.tudelft.nl/en/ceg\">\n",
+    "      <img alt=\"TU Delft\" style=\"width:100px; height:auto;\" src=\"https://gitlab.tudelft.nl/mude/public/-/raw/main/tu-logo/TU_P1_full-color.png\" />\n",
+    "    </a>\n",
+    "    <a rel=\"license\" href=\"http://creativecommons.org/licenses/by/4.0/\">\n",
+    "      <img alt=\"Creative Commons License\" style=\"width:88px; height:auto;\" src=\"https://i.creativecommons.org/l/by/4.0/88x31.png\" />\n",
+    "    </a>\n",
+    "  </div>\n",
+    "  <div style=\"font-size: 75%; margin-top: 10px; text-align: right;\">\n",
+    "    This file is from the <a rel=\"2024 Textbook\" href=\"http://mude.citg.tudelft.nl/2024/book\">2024 edition of the MUDE Textbook</a>. \n",
+    "  </div>\n",
+    "  <div style=\"font-size: 75%; margin-top: 10px; text-align: right;\">\n",
+    "    &copy; Copyright 2024 TU Delft, <a rel=\"license\" href=\"http://creativecommons.org/licenses/by/4.0/\">CC BY 4.0 License</a>.\n",
+    "  </div>\n",
+    "</div>\n",
+    "<p hidden>% CREDIT-NOTE source: optimization</p>"
+   ]
   }
  ],
  "metadata": {

--- a/book/optimization/general.md
+++ b/book/optimization/general.md
@@ -173,3 +173,11 @@ This example is taken from the MSc thesis ​of Stavros Xanthopoulos
 This example is taken from the PhD thesis ​of Bahman Madadi​
 
 ```
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT

--- a/book/optimization/general.md
+++ b/book/optimization/general.md
@@ -178,6 +178,6 @@ This example is taken from the PhD thesis ​of Bahman Madadi​
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT

--- a/book/optimization/genetic_algorithm.md
+++ b/book/optimization/genetic_algorithm.md
@@ -329,6 +329,6 @@ Finally, using complete replacement our new population is given by:
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT

--- a/book/optimization/genetic_algorithm.md
+++ b/book/optimization/genetic_algorithm.md
@@ -324,3 +324,11 @@ After this, we apply the **single-point crossover** to get:
 Finally, using complete replacement our new population is given by:
 
 ![Untitled](https://files.mude.citg.tudelft.nl/Untitled_9.png)
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT

--- a/book/optimization/gurobi.md
+++ b/book/optimization/gurobi.md
@@ -1,13 +1,3 @@
----
-layout: page
-title: Gurobi
-# description: 
-# nav_order: 6
-nav_exclude: true
----
-
-<!-- [deepnote.com](https://deepnote.com/) -->
-
 # Gurobi
 
 Gurobi is an optimizer written in Python. It's not open-source, but an academic license is available. This page shows how to activate the license. General instructions are available on [their support website](https://support.gurobi.com/hc/en-us/articles/14799677517585) as well, if additional information is needed.

--- a/book/optimization/integer_programming.md
+++ b/book/optimization/integer_programming.md
@@ -111,6 +111,6 @@ Let us take a look into the solving process using the branch-and-bound method:
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT

--- a/book/optimization/integer_programming.md
+++ b/book/optimization/integer_programming.md
@@ -106,3 +106,11 @@ Let us take a look into the solving process using the branch-and-bound method:
 :::{card} Quiz questions
 <iframe src="https://tudelft.h5p.com/content/1292123858535891397/embed" aria-label="2_3_4_1_branch_and_bound" width="1088" height="637" frameborder="0" allowfullscreen="allowfullscreen" allow="autoplay *; geolocation *; microphone *; camera *; midi *; encrypted-media *"></iframe><script src="https://tudelft.h5p.com/js/h5p-resizer.js" charset="UTF-8"></script>
 :::
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT

--- a/book/optimization/origins.md
+++ b/book/optimization/origins.md
@@ -50,6 +50,6 @@ Dantzig's core insight was to realize that most such ground objectives can many 
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT

--- a/book/optimization/origins.md
+++ b/book/optimization/origins.md
@@ -45,3 +45,11 @@ Input/output matrix in a simple economy:
 Without an objective, a vast number of solutions can be feasible. To find the "best" feasible solution, we need an expression to describe how goals can be achieved as opposed to specifying a specific value for this goal on itself. For example, it’s not about transporting 1000 soldiers but finding a way to transport as many as possible with the existing resources.
 
 Dantzig's core insight was to realize that most such ground objectives can many times be translated into a **linear objective function** that needs to be maximized (or minimized) that measures the quality/performance of the solutions. Development of the final method, the so-called **simplex** method, was evolutionary and happened over a period of about a year.
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT

--- a/book/optimization/overview.md
+++ b/book/optimization/overview.md
@@ -1,4 +1,13 @@
+(optimization)=
 # Optimization
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT
 
 In this chapter you will learn all the basics of optimization. The chapter covers the origins of optimization as well as the main methods that exist to solve these problems. You will learn the following:
 

--- a/book/optimization/overview.md
+++ b/book/optimization/overview.md
@@ -5,7 +5,7 @@
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT
 

--- a/book/optimization/performance.md
+++ b/book/optimization/performance.md
@@ -130,3 +130,11 @@ If we see another example, now with $n>>m$ and 40% non-zero elements in matrix A
 ## Problem type
 
 When it comes to the problem type, the first thing that we immediately think is, of course, about the objective function and the constraints we will have to deal in each case. However, for LP problems this **does not matter**. What does matter is the type of the decision variables that we are talking about (discrete, continuous, mixed), as we have seen in the last example!
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT

--- a/book/optimization/performance.md
+++ b/book/optimization/performance.md
@@ -135,6 +135,6 @@ When it comes to the problem type, the first thing that we immediately think is,
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT

--- a/book/optimization/performance_generic_LP.ipynb
+++ b/book/optimization/performance_generic_LP.ipynb
@@ -1246,7 +1246,7 @@
     "% source: optimization\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/optimization/performance_generic_LP.ipynb
+++ b/book/optimization/performance_generic_LP.ipynb
@@ -1237,6 +1237,19 @@
     "\n",
     "Play around with different values of the sparsity parameter and see if it affects the results. Based on the outcome, would you consider sparsity of the matrix $A$ a factor in determining the best performing algorithm?"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: optimization\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/optimization/performance_generic_LP_stripped.ipynb
+++ b/book/optimization/performance_generic_LP_stripped.ipynb
@@ -1219,6 +1219,34 @@
     "\n",
     "Play around with different values of the sparsity parameter and see if it affects the results. Based on the outcome, would you consider sparsity of the matrix $A$ a factor in determining the best performing algorithm?"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**End of notebook.**\n",
+    "\n",
+    "<div style=\"margin-top: 50px; padding-top: 20px; border-top: 1px solid #ccc;\">\n",
+    "  <div style=\"display: flex; justify-content: flex-end; gap: 20px; align-items: center;\">\n",
+    "    <a rel=\"MUDE\" href=\"http://mude.citg.tudelft.nl/\">\n",
+    "      <img alt=\"MUDE\" style=\"width:100px; height:auto;\" src=\"https://gitlab.tudelft.nl/mude/public/-/raw/main/mude-logo/MUDE_Logo-small.png\" />\n",
+    "    </a>\n",
+    "    <a rel=\"TU Delft\" href=\"https://www.tudelft.nl/en/ceg\">\n",
+    "      <img alt=\"TU Delft\" style=\"width:100px; height:auto;\" src=\"https://gitlab.tudelft.nl/mude/public/-/raw/main/tu-logo/TU_P1_full-color.png\" />\n",
+    "    </a>\n",
+    "    <a rel=\"license\" href=\"http://creativecommons.org/licenses/by/4.0/\">\n",
+    "      <img alt=\"Creative Commons License\" style=\"width:88px; height:auto;\" src=\"https://i.creativecommons.org/l/by/4.0/88x31.png\" />\n",
+    "    </a>\n",
+    "  </div>\n",
+    "  <div style=\"font-size: 75%; margin-top: 10px; text-align: right;\">\n",
+    "    This file is from the <a rel=\"2024 Textbook\" href=\"http://mude.citg.tudelft.nl/2024/book\">2024 edition of the MUDE Textbook</a>. \n",
+    "  </div>\n",
+    "  <div style=\"font-size: 75%; margin-top: 10px; text-align: right;\">\n",
+    "    &copy; Copyright 2024 TU Delft, <a rel=\"license\" href=\"http://creativecommons.org/licenses/by/4.0/\">CC BY 4.0 License</a>.\n",
+    "  </div>\n",
+    "</div>\n",
+    "<p hidden>% CREDIT-NOTE source: optimization</p>"
+   ]
   }
  ],
  "metadata": {

--- a/book/optimization/project.md
+++ b/book/optimization/project.md
@@ -5,7 +5,7 @@
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter reuses content Bahman Ahmadi et al. (2024). {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter reuses content Bahman Ahmadi et al. (2024). {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT
 
@@ -269,6 +269,6 @@ A solution of the problem
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT

--- a/book/optimization/project.md
+++ b/book/optimization/project.md
@@ -1,4 +1,14 @@
+(optimization_project)=
 # Road Network Design Problem
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content Bahman Ahmadi et al. (2024). {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT
+
 During Friday’s session, you will work on the road Network Design Problem (NDP) and explore its implementation using two optimization approaches: Mixed-Integer Linear Programming (MILP) and a Genetic Algorithm (GA). The problem description, mathematical formulation, and Python implementation are provided in this book, should you wish to prepare in advance for the session.
 
 ```{admonition} MUDE Exam Information
@@ -254,3 +264,11 @@ height: 500px
 ---
 A solution of the problem
 ```
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT

--- a/book/optimization/sand_and_clay.md
+++ b/book/optimization/sand_and_clay.md
@@ -112,6 +112,6 @@ If we calculate the value of the objective function for the remaining vertices w
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT

--- a/book/optimization/sand_and_clay.md
+++ b/book/optimization/sand_and_clay.md
@@ -107,3 +107,11 @@ If we calculate the value of the objective function for the remaining vertices w
 :::{card} Quiz questions
 <iframe src="https://tudelft.h5p.com/content/1292121213033110307/embed" aria-label="2_3_2_2_graphical_solution_method" width="1088" height="637" frameborder="0" allowfullscreen="allowfullscreen" allow="autoplay *; geolocation *; microphone *; camera *; midi *; encrypted-media *"></iframe><script src="https://tudelft.h5p.com/js/h5p-resizer.js" charset="UTF-8"></script>
 :::
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT

--- a/book/optimization/sand_and_clay_simplex.md
+++ b/book/optimization/sand_and_clay_simplex.md
@@ -207,3 +207,11 @@ So, this is the optimal solution
 The SIMPLEX workflow is shown in the scheme below:
 
 ![sand_clay_14](https://files.mude.citg.tudelft.nl/sand_clay_14.png)
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT

--- a/book/optimization/sand_and_clay_simplex.md
+++ b/book/optimization/sand_and_clay_simplex.md
@@ -212,6 +212,6 @@ The SIMPLEX workflow is shown in the scheme below:
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT

--- a/book/optimization/simplex_exercise.md
+++ b/book/optimization/simplex_exercise.md
@@ -62,6 +62,6 @@ Find the graphical solution of this problem. Does it give the same solution as u
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT

--- a/book/optimization/simplex_exercise.md
+++ b/book/optimization/simplex_exercise.md
@@ -57,3 +57,11 @@ Find the graphical solution of this problem. Does it give the same solution as u
 ````
 
 **Note:** in this problem and solution the intersection between the gradient and the constraints is not important (see figure), but rather the _direction_ that is important! It is a coincidence that the intersection is the optimal solution.
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT

--- a/book/optimization/some_constraints.md
+++ b/book/optimization/some_constraints.md
@@ -58,6 +58,6 @@ $y$ is obviously the continuous variable you want to get.
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT

--- a/book/optimization/some_constraints.md
+++ b/book/optimization/some_constraints.md
@@ -53,3 +53,11 @@ The product $x_1x_2$ of the binary variable $x_1$ and the continuous variable $x
 $$\begin{cases}y\leq ux_1\\ y\leq x_2\\ y\geq x_2-u(1-x_1)\\ y\geq 0\end{cases}$$
 
 $y$ is obviously the continuous variable you want to get.
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT

--- a/book/optimization/taxonomy.md
+++ b/book/optimization/taxonomy.md
@@ -76,6 +76,6 @@ $$\begin{gather*}\text{Prob}(nC\leq 50M)\geq 0.9\\ \text{Prob}(nC_m\leq 0.7M)\ge
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT

--- a/book/optimization/taxonomy.md
+++ b/book/optimization/taxonomy.md
@@ -71,3 +71,11 @@ In the WT farm case, even though the constraints defined above are linear (conve
 The problem as defined with the constraints above is deterministic. However, in case the construction, $C$, and the maintenance costs, $C_m$, present variability, the problem is stochastic and we find, for example:
 
 $$\begin{gather*}\text{Prob}(nC\leq 50M)\geq 0.9\\ \text{Prob}(nC_m\leq 0.7M)\geq 0.95\end{gather*}$$
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT

--- a/book/optimization/videos.md
+++ b/book/optimization/videos.md
@@ -14,3 +14,11 @@ _In case small errors are present in the videos, please refer to the appropriate
 
     <iframe width="560" height="315" src="https://www.youtube.com/embed/lJssLZWEPW8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 ```
+
+% START-CREDIT
+% source: optimization
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+```
+% END-CREDIT

--- a/book/optimization/videos.md
+++ b/book/optimization/videos.md
@@ -19,6 +19,6 @@ _In case small errors are present in the videos, please refer to the appropriate
 % source: optimization
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {fa}`quote-left`{ref}`Find out more here <optimization_credit>`.
+This chapter is written by Gonçalo Homem de Almeida Correia, Maria Nogal Macho, Jie Gao and Bahman Ahmadi. {ref}`Find out more here <optimization_credit>`.
 ```
 % END-CREDIT

--- a/book/pd/exercises/exercise-dam.md
+++ b/book/pd/exercises/exercise-dam.md
@@ -163,3 +163,11 @@ $$
  
 The most stringent of the two criteria applies, so the proposed safety standard would be $10^{-6}$ per year for the given inputs.
 ```
+
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman and Robert Lanzafame. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/pd/exercises/exercise-fn-curve.md
+++ b/book/pd/exercises/exercise-fn-curve.md
@@ -66,3 +66,11 @@ name: FN-curve
 FN-curve for exercise 4
 ```
 ````
+
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman and Robert Lanzafame. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/pd/exercises/exercise-paint.md
+++ b/book/pd/exercises/exercise-paint.md
@@ -175,3 +175,11 @@ name: optimization-curve
 Optimization curve for exercise 12
 ```
 ````
+
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman and Robert Lanzafame. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/pd/exercises/exercise-sample-exam.md
+++ b/book/pd/exercises/exercise-sample-exam.md
@@ -246,3 +246,11 @@ Comments about answers that were not quite right (points were not deduced for th
 
 Common ‘objects’: -->
 
+
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman and Robert Lanzafame. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/pd/exercises/overview.md
+++ b/book/pd/exercises/overview.md
@@ -1,5 +1,13 @@
 # Exercises
 
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman and Robert Lanzafame. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT
+
 A number of exercises are included in this chapter that illustrate the previously discussed concepts of risk and reliability in a probabilistic design context. At the end a set of **sample exam** questions are included. 
 
 <!--

--- a/book/pd/intro.md
+++ b/book/pd/intro.md
@@ -1,6 +1,14 @@
 (risk)=
 # Risk Analysis
 
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman and Robert Lanzafame. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT
+
 Throughout this book we have focused on a variety of deterministic and probabilistic topics, which probably appeared to be completely unrelated. However, in engineering practice we often need to combine deterministic and probabilistic approaches to design and assess the projects we work on and Risk Analysis concepts are an important way to facilitate this. In particular, concepts in this chapter are focused not so much on evaluating the behavior of a particular system, but rather _evaluating the risk associated with various outcomes_ and, most importantly, providing _a framework with which decisions can be made to improve it._
 
 **Risk and Reliability in Practice**

--- a/book/pd/risk-analysis/definition.md
+++ b/book/pd/risk-analysis/definition.md
@@ -118,3 +118,10 @@ Substantial research has also focused on factors that determine the perception o
   - Weight of possible undesired consequences (‘loss’) relative to comparable possible desired consequences
 :::
 
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman and Robert Lanzafame. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/pd/risk-analysis/overview.md
+++ b/book/pd/risk-analysis/overview.md
@@ -1,5 +1,13 @@
 # Introduction to Risk Analysis
 
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman and Robert Lanzafame. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT
+
 This book splits risk into two parts: risk *introduction* and risk *evaluation.* This chapter in particular introduces the _analysis_ of risks from a broad perspective, beginning with definitions and key steps of a risk analysis, illustrated quantitatively through an FN curve. The next chapter covers risk _evaluation_ concepts decision theory, cost benefit analysis and safety standards, where the principal focus is on making decisions and answering the question 'how safe is safe enough?'
 
 ```{note}

--- a/book/pd/risk-analysis/risk-curves.md
+++ b/book/pd/risk-analysis/risk-curves.md
@@ -106,3 +106,11 @@ Exceedance probability (FN curve), $1-F_N(n)$.
 :class: tip
 You can practice constructing a simple FN curve in {ref}`ex_fn_curve`, although some of the questions require knowledge of limit lines, introduced in the {ref}`safety_standards` Section.
 ```
+
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman and Robert Lanzafame. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/pd/risk-analysis/steps.md
+++ b/book/pd/risk-analysis/steps.md
@@ -145,3 +145,11 @@ Given the nature of the key question "how safe is safe enough?", several politic
 If the risks evaluated in first four steps of a risk analysis are considered unacceptable, several forms of risk reduction can be implemented, such as changes to the engineered system, or changes to its organization and management. It can be helpful to determine how risk can be controlled, for example by monitoring, inspection or maintenance.
 
 Post-accident analysis indicates that human and organizational errors are still a major cause of failure in civil engineering systems, and it seems that the only suitable way to reduce human errors is by the incorporation of sufficient control in different phases of the construction process {cite:p}`taerwe1986`, and by a thorough education of all personnel involved. Therefore, an extensive interaction between the safety methodology and quality management is a necessity in order to guarantee the safety of infrastructure.
+
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman and Robert Lanzafame. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/pd/risk-evaluation/cost-benefit.md
+++ b/book/pd/risk-evaluation/cost-benefit.md
@@ -146,3 +146,11 @@ An extensive study on  values in various sectors, see {cite:t}`tengs1995` showed
 
 One other approach is to base the value of a human life on macro-economic indicators. Several metrics have been proposed that relate this value to a person’s economic production.
 Given the difficulties associated with economic valuation of human life and the associated risk reduction, it is decided in some domains to develop separate criteria for considering the risk to life. This topic is further elaborated in ⚠️section 3.5.
+
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/pd/risk-evaluation/decision.md
+++ b/book/pd/risk-evaluation/decision.md
@@ -206,3 +206,11 @@ name: example-river-excavation-3
 Decision tree with probabilities and costs.
 ```
 ````
+
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/pd/risk-evaluation/econ-optimization.md
+++ b/book/pd/risk-evaluation/econ-optimization.md
@@ -60,3 +60,11 @@ $$
 This approach can be applied to various decisions problems, such as the optimal dike height (see next section) but also the dimensioning of other interventions such as sprinklers or ventilation in tunnels to reduce fire risks. In cases where no continuous functions are available to create a curve as in {numref}`economic_optimum`, the analyst can consider a limited number of design options (e.g. no, small, medium or large sprinklers in a tunnel) and determine investments, risks and total costs for these options.
 
 In addition to the determination of the optimal failure probability, the cost benefit criterion should still be verified. (It is possible that we find an economic optimum with higher total costs than in the current situation without interventions). It is checked whether the benefits of risk reduction are larger than the costs of the dike heightening, i.e. $(P_{f,0} - P_{f,opt}) D > I$.
+
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/pd/risk-evaluation/example-dike-height.md
+++ b/book/pd/risk-evaluation/example-dike-height.md
@@ -119,3 +119,11 @@ name: periodic_investments
 ---
 Periodic investments in dike reinforcement for a situation with sea level rise.
 ```
+
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/pd/risk-evaluation/overview.md
+++ b/book/pd/risk-evaluation/overview.md
@@ -1,6 +1,14 @@
 (risk_eval)=
 # Risk Evaluation
 
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT
+
 This chapter focuses on the evaluation of risk (Step 4) by applying several different techniques. While the Sections may seem long, the methods are relatively simple and a lot of examples and explanations are provided to illustrate how they can be applied in practice. After this chapter, you will be ready to try all of the practice problems in the Exercise Chapter.
 
 ```{note}

--- a/book/pd/risk-evaluation/safety-standards.md
+++ b/book/pd/risk-evaluation/safety-standards.md
@@ -370,3 +370,11 @@ One field of application where these concepts have been applied concerns the flo
 [^neutral]: It should be noted that the usage of the term “risk neutral” to describe the FN-curve limit line for $\alpha = 1$ is widespread but, strictly speaking, incorrect in the context of decision theory (see {ref}`decision` Section). This is because the cost of risk bearing to a risk neutral decision maker equals expected loss (i.e. the product of probabilities and damages). The FN-curve shows cumulative probabilities, however. Also, an individual crossing of the limit line would not necessarily disturb a risk neutral decision maker, provided the other accident scenarios have relatively small probabilities.  
 [^taw]: TAW is nowadays called ENW: Extertise Network on Flood Protection.
 [^men]: The group 'young men' is used as a baseline because this was the only information available at the time the study was completed.
+
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Bas Jonkman. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/pd/videos.md
+++ b/book/pd/videos.md
@@ -28,3 +28,11 @@ _This is especially useful for the Simple City exercise (Question 1)._
 
     <iframe width="560" height="315" src="https://www.youtube.com/embed/sxPmBdpLz94" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 ```
+
+% START-CREDIT
+% source: risk
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses content written by Robert Lanzafame. {ref}`Find out more here <risk_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/probability/Exponential.md
+++ b/book/probability/Exponential.md
@@ -77,3 +77,11 @@ Assume that floods are independent and identically distributed. This means that 
 <iframe src="https://tudelft.h5p.com/content/1292083679343540347/embed" aria-label="Exponential" width="1088" height="637" frameborder="0" allowfullscreen="allowfullscreen" allow="autoplay *; geolocation *; microphone *; camera *; midi *; encrypted-media *"></iframe><script src="https://tudelft.h5p.com/js/h5p-resizer.js" charset="UTF-8"></script>
 
 ```
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/Exponential_quiz.md
+++ b/book/probability/Exponential_quiz.md
@@ -36,3 +36,11 @@ $$
 This means that there is a probability of observing a flood of 1 - 0.82 = 0.18, which is actually pretty high! Maybe the engineer should think about a tighter schedule or using some adaptive techniques so the construction works are not affected by events that low.
 
 ```
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/GOF.md
+++ b/book/probability/GOF.md
@@ -159,3 +159,11 @@ According to the Kolmogorov-Smirnov test, it is not possible to reject that the 
 However, the plot in log-scale is also available. There, it is shown how the Gumbel distribution fits way better the tail of the empirical distribution. Since the goal of the engineer is to infer events that have not been observed yet (extrapolate), the tail is extremely important. Consequently, Gumbel distribution would be preferred in this context to model the axel loads observations.
 
 ```
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/GOF_quiz.md
+++ b/book/probability/GOF_quiz.md
@@ -26,3 +26,11 @@ According to the Kolmogorov-Smirnov test, it is not possible to reject that the 
 However, the plot in log-scale is also available. There, it is shown how the Gumbel distribution fits way better the tail of the empirical distribution. Since the goal of the engineer is to infer events that have not been observed yet (extrapolate), the tail is extremely important. Consequently, Gumbel distribution would be preferred in this context to model the axel loads observations.
 
 ```
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/Gaussian.md
+++ b/book/probability/Gaussian.md
@@ -42,3 +42,11 @@ Gaussian distribution function: PDF and CDF.
 ## Some properties
 
 The mean, median and mode of the Normal distribution is equal to $\mu$. The variance is $\sigma^2$. Note that Normal distribution is symmetric and presents 0 skewness. 
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/Gumbel.md
+++ b/book/probability/Gumbel.md
@@ -86,3 +86,11 @@ Chlorides between 1mg/L an 100mg/L are normal in freshwater. Use the Gumbel dist
 
 <iframe src="https://tudelft.h5p.com/content/1292083690582888367/embed" aria-label="Gumbel" width="1088" height="637" frameborder="0" allowfullscreen="allowfullscreen" allow="autoplay *; geolocation *; microphone *; camera *; midi *; encrypted-media *"></iframe><script src="https://tudelft.h5p.com/js/h5p-resizer.js" charset="UTF-8"></script>
 ```
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/Gumbel_quiz.md
+++ b/book/probability/Gumbel_quiz.md
@@ -51,3 +51,11 @@ $$
 This probability is very small, so the engineers can conclude that the water in the aquifer seems to present the characteristics of fresh water regarding the concentration of Chlorides.
 
 ```
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/Loc-scale.ipynb
+++ b/book/probability/Loc-scale.ipynb
@@ -208,6 +208,20 @@
         "ax.set_xlabel('x')\n",
         "ax.set_ylabel('pdf');"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2b773abf",
+      "metadata": {},
+      "source": [
+        "% START-CREDIT\n",
+        "% source: distributions\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/probability/Lognormal.md
+++ b/book/probability/Lognormal.md
@@ -67,3 +67,11 @@ PDF and CDF of Lognormal distribution to describe overtopping volumes $V (l/m)$.
 ```````
 
 [^ref]: "Lognormal Distribution" by StijnDeVuyst is licensed under CC BY-SA 4.0. To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/?ref=openverse.
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/Lognormal_quiz.md
+++ b/book/probability/Lognormal_quiz.md
@@ -63,3 +63,11 @@ You can see that the mean = 474l/m >> median = 250l/m, indicating that the distr
 ---
 
 ```
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/MLE_1.ipynb
+++ b/book/probability/MLE_1.ipynb
@@ -138,7 +138,15 @@
    "cell_type": "markdown",
    "id": "19bd80a8",
    "metadata": {},
-   "source": []
+   "source": [
+    "% START-CREDIT\n",
+    "% source: distributions\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/probability/PDF_CDF.md
+++ b/book/probability/PDF_CDF.md
@@ -23,15 +23,21 @@ $X$ has a value less than $x$**.
 
 Below, you find an interactive element that illustrates the relationship between the integral of the pdf and the cdf value. They grey-shaded area in the left subplot corresponds to the integral from $-\infty$ to $x$. Move your mouse over either the subplots and try to develop an intuition for how both distributions relate to each other. When is the cdf steep, when is it flat?
 
-<iframe src="../_static/elements/element_pdf_and_cdf.html" width="800" height="400" frameborder="0"></iframe>
-
 % START-CREDIT
 % source: maxramgraber
+````{margin}
 ```{attributiongrey} Attribution
 :class: attribution
 This interactive figure is created by Max Ramgraber. {ref}`Find out more here <distributions_credit>`.
 ```
+````
 % END-CREDIT
+
+````{iframe-figure} ../_static/elements/element_pdf_and_cdf.html
+:name: pdf_cdf
+
+Interactively visualize the relationship between the PDF and the CDF (the integral of the PDF value).
+````
 
 It should be easy to see from the definition of the CDF that the probability of observing an exact value of a continuous random variable is exactly zero. This is an important observation, and also an important characteristic that separates continuous and discrete random variables.
 
@@ -60,17 +66,24 @@ name: gaussian distr
 Gaussian distribution function: PDF and CDF.
 ```
 
-Below, you will find an interactive element that allows you to explore the influence of different means and standard deviations on the pdf and cdf. Experiment with both options and observe how it affects the shape of both distributions.
+Below, you will find an interactive element that allows you to explore the influence of different means and standard deviations on the PDF and CDF. Experiment with both options and observe how it affects the shape of both distributions.
 
-<iframe src="../_static/elements/element_Gaussian_cdf_moments.html" width="800" height="445" frameborder="0"></iframe>
 
 % START-CREDIT
 % source: maxramgraber
+````{margin}
 ```{attributiongrey} Attribution
 :class: attribution
 This interactive figure is created by Max Ramgraber. {ref}`Find out more here <distributions_credit>`.
 ```
+````
 % END-CREDIT
+
+````{iframe-figure} ../_static/elements/element_Gaussian_cdf_moments.html
+:name: pdf_cdf_2
+
+Interactively change the mean and standard deviation of the Gaussian distribution to visualize the effect on the PDF and CDF.
+````
 
 ## Probability of other intervals
 

--- a/book/probability/PDF_CDF.md
+++ b/book/probability/PDF_CDF.md
@@ -25,6 +25,14 @@ Below, you find an interactive element that illustrates the relationship between
 
 <iframe src="../_static/elements/element_pdf_and_cdf.html" width="800" height="400" frameborder="0"></iframe>
 
+% START-CREDIT
+% source: maxramgraber
+```{attributiongrey} Attribution
+:class: attribution
+This interactive figure is created by Max Ramgraber. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT
+
 It should be easy to see from the definition of the CDF that the probability of observing an exact value of a continuous random variable is exactly zero. This is an important observation, and also an important characteristic that separates continuous and discrete random variables.
 
 ## PDF and CDF of Gaussian distribution
@@ -56,6 +64,14 @@ Below, you will find an interactive element that allows you to explore the influ
 
 <iframe src="../_static/elements/element_Gaussian_cdf_moments.html" width="800" height="445" frameborder="0"></iframe>
 
+% START-CREDIT
+% source: maxramgraber
+```{attributiongrey} Attribution
+:class: attribution
+This interactive figure is created by Max Ramgraber. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT
+
 ## Probability of other intervals
 
 We saw that the CDF provides us with the non-exceedance probabilities, this is $[-\infty, x]$. But what happens if we are interested in the probabilities of another intervals? It is common to be interested in the probability of exceeding a value. For instance, wind speeds over a value can damage an structure or concentrations of a nutrient higher than a value can lead to eutrophication. Therefore, we want to integrate  from a value $x$ to $\infty$. Here the probability axioms make this easy, since the PDF integrates to 1 over the sample space of the random variable:
@@ -86,3 +102,11 @@ $$
 ## Inverse CDF
 
 Often, in regulations and guidelines, it is required to design our structure or system for a value which is not exceeded more than $p$ percent of the time. Thus, we are facing the opposite problem: what is the value of the random variable, $x$, whose non-exceedance probability has a specified value, $p$? The solution is simple: the inverse of the CDF, $x = F^{-1}(p)$. As previously mentioned, the CDF is just an equation which in most occasions can be solved analytically, so we just need to work through the formula and calculate $x$ given $p$.
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/Param_distr.md
+++ b/book/probability/Param_distr.md
@@ -17,3 +17,11 @@ In the following sections, you will be introduced to some of the most commonly u
 :class: tip, dropdown
 You do not need to know the equations of the distribution functions by heart. You just need to know how the distribution looks (PDF/CDF), how it responds to changes in the parameters and some basic properties (symmetry or bounds).
 ```
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/Reminder_intro.md
+++ b/book/probability/Reminder_intro.md
@@ -1,6 +1,14 @@
 (cont_dist)=
 # Univariate Continuous Distributions
 
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT
+
 Civil engineering and Geosciences involve working with nature and that comes with associated [uncertainties](https://mude.citg.tudelft.nl/book/propagation_uncertainty/uncertainty.html). Natural phenomena have an intrinsic aleatoric uncertainty that we need to model. Moreover, we don't always have the resources to neglect the epistemic uncertainty; we typically need to make decisions in scenarios of data scarcity. 
 
 This is where probability in general and continuous distributions in particular come in indispensable as they model the uncertainty and allow to assess the risk in our decisions and incorporate it in the decision-making process.

--- a/book/probability/Uniform.md
+++ b/book/probability/Uniform.md
@@ -51,3 +51,11 @@ Var[X] = \frac{1}{12}(b-a)^2
 $$
 
 Finally, note that uniform distribution is symmetric and presents 0 skewness. Thus, the median and the mean are identical. This is, it does not present any tail.
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/empirical.md
+++ b/book/probability/empirical.md
@@ -82,3 +82,11 @@ Empirical probability density function of the wind speed data.
 ```
 
 [^density]: Happily, in most coding languages, the algorithm to compute the pdf is already implemented and we just need to plot a histogram selecting the option to show us the densities.
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/fitting.md
+++ b/book/probability/fitting.md
@@ -7,3 +7,11 @@ In the previous sections, we introduced parametric distributions as mathematical
 - Maximum loglikelihood estimator (MLE)
 
 Note that it assumes that we know the parametric distribution we want to fit. For instance, fitting an Exponential distribution to a sample of observations. So, how do I choose between them? The choice of the appropriate distribution function needs to be based first on the physics of the random variable we are studying. Once we have accounted for those physical characteristics, we can make use of goodness of fit (GOF) techniques to support our decision. In the subsequent sections, some commonly used GOF techniques in the statistics field are also presented.
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/moments.md
+++ b/book/probability/moments.md
@@ -97,3 +97,11 @@ $$
 
 [^moment]: We denote as moments in statistics to the quantitative properties to characterize a distribution. The four commonly used moments are the mean, the variance, the skewness and the kurtosis.
 [^ref]: Data extracted from Kottegoda and Rosso (2008).
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/moments_quiz.md
+++ b/book/probability/moments_quiz.md
@@ -68,3 +68,11 @@ $$
 
 Thus, there is a probability of 0.80 to fulfill the required resistence and a probabiltiy of 0.20 of not doing it. He will have to contact the contractor!
 ```
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/other_distr.md
+++ b/book/probability/other_distr.md
@@ -53,3 +53,11 @@ In the following sections, we will introduce some common parametric distribution
 [^mode]: The mode is the most frequently observed value and, thus, the value of the distribution with the highest value of the density in its PDF.
 [^mean]: Visually from the PDF, we can define the mean as the value of the random variable which is the balance point of the distribution.
 [^median]: Visually from the PDF, we can define the median as the value of the random variable which divides the PDF in two areas of the same value.
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/probability/python.ipynb
+++ b/book/probability/python.ipynb
@@ -954,6 +954,19 @@
     "p = cdf([5, 8])\n",
     "print(f'The probability calculated using the Clayton copula is {p:.4f}')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: distributions\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/probability/scipy_exercises.ipynb
+++ b/book/probability/scipy_exercises.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# `scipy.stats`: **Examples from MUDE Textbook**\n",
     "\n",
-    "This notebook contains all of the cells from a page in the online textbook, but leaves out the text explanation at the top."
+    "This notebook contains all of the cells from a page in the online textbook, but leaves out the text explanation at the top. It is from the [MUDE Textbook](https://mude.citg.tudelft.nl/2024/book/)."
    ]
   },
   {

--- a/book/probability/summary.md
+++ b/book/probability/summary.md
@@ -39,3 +39,11 @@ $
 :class: tip, dropdown
 You do not need to know the equations of the distribution functions by heart. You just need to know how the distribution looks (PDF/CDF), how it responds to changes in the parameters and some basic properties (symmetry or bounds).
 ```
+
+% START-CREDIT
+% source: distributions
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Patricia Mares Nasarre and Robert Lanzafame. {ref}`Find out more here <distributions_credit>`.
+```
+% END-CREDIT

--- a/book/programming/gurobi.md
+++ b/book/programming/gurobi.md
@@ -1,6 +1,14 @@
 (gurobi)=
 # Gurobi Optimization Software
 
+% START-CREDIT
+% source: programming
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses material from _Python for Engineers_. {ref}`Find out more here <programming_credit>`.
+```
+% END-CREDIT
+
 Gurobi is an optimization software that consists of two parts:
 
 1. A closed-source optimizer software that can be installed on your computer and requires a license (an academic license is free).

--- a/book/programming/week_1_1.md
+++ b/book/programming/week_1_1.md
@@ -1,6 +1,14 @@
 (week_1_1_programming)=
 # Programming, Week 1.1: Getting Started!
 
+% START-CREDIT
+% source: programming
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses material from _Learn Programming for Engineers_. {ref}`Find out more here <programming_credit>`.
+```
+% END-CREDIT
+
 The purpose of this week is to get software installed and be prepared to work with Python code and Jupyter Notebooks. This includes some programming "theory" to help you understand what you are doing with the MUDE software stack, and why we use particular tools. A brief introduction to [Computers and Computing Environments](week_1_1/environments.md) is provided before the [software installation instructions](week_1_1/install.md). Once the software is ready, you are able to read and implement the information in: the [File System](week_1_1/files.md) and [Python Warmup](week_1_1/warmup.ipynb) sections:
 
 % This chapter relies heavily on material proved in the [Learn programming book](https://teachbooks.github.io/learn-programming)

--- a/book/programming/week_1_2.md
+++ b/book/programming/week_1_2.md
@@ -1,4 +1,12 @@
 (week_1_2_programming)=
 # Week 1.2: Python Topics
 
+% START-CREDIT
+% source: programming
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses material from _Learn Programming for Engineers_. {ref}`Find out more here <programming_credit>`.
+```
+% END-CREDIT
+
 This week the programming topics were covered in a Jupyter notebook and based on general Python topics, most of which should have been covered in a BSc course on programming. The [Learn Python book](https://teachbooks.github.io/learn-python) may be a useful reference.

--- a/book/programming/week_1_3.md
+++ b/book/programming/week_1_3.md
@@ -1,6 +1,14 @@
 (week_1_3_programming)=
 # Week 1.3: VS Code Live Share!
 
+% START-CREDIT
+% source: programming
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses material from _Learn Programming for Engineers_. {ref}`Find out more here <programming_credit>`.
+```
+% END-CREDIT
+
 This week you'll learn some first VS Code lifehacks! Let's dive into it!
 
 % This chapter relies heavily on material proved in the [Learn programming book](https://teachbooks.github.io/learn-programming)

--- a/book/programming/week_1_4.md
+++ b/book/programming/week_1_4.md
@@ -1,3 +1,11 @@
 # Week 1.4: Version control with Git!
 
+% START-CREDIT
+% source: programming
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses material from _Learn Programming for Engineers_. {ref}`Find out more here <programming_credit>`.
+```
+% END-CREDIT
+
 This week you'll learn how to do version control with Git

--- a/book/programming/week_1_5.md
+++ b/book/programming/week_1_5.md
@@ -1,5 +1,7 @@
 # Week 1.5: Collaboration with Git!
 
+
+
 This week you'll learn how to actually do version control with Git in collaborative sense.
 
 In MUDE, you can do all assignments without this workflow. However, feel free to use it in your collaborative projects in MUDE or elsewhere!

--- a/book/programming/week_1_6.md
+++ b/book/programming/week_1_6.md
@@ -1,5 +1,13 @@
 # Week 1.6: Errors
 
+% START-CREDIT
+% source: programming
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses material from _Python for Engineers_. {ref}`Find out more here <programming_credit>`.
+```
+% END-CREDIT
+
 At this point you are used to the fact that bugs in your code are a fact of life, but probably don't have a methodical way of dealing with them. Perhaps sometimes you get errors and and have no idea how to fix them. This week we will consider various _error types_ and promote a structured approach to debugging by learning about the _traceback_ feature in Python.
 
 This week we introduce several tools that while simple, form foundational elements of the broader field of _software testing._ If you ever use or write more complex (i.e., a collection of Python functions, modules or a package), these tools are essential.MUDE or elsewhere!

--- a/book/programming/week_1_7.md
+++ b/book/programming/week_1_7.md
@@ -1,6 +1,14 @@
 (oop)=
 # Week 1.7: OOP
 
+% START-CREDIT
+% source: programming
+```{attributiongrey} Attribution
+:class: attribution
+This chapter reuses material from _Learn Programming for Engineers_. {ref}`Find out more here <programming_credit>`.
+```
+% END-CREDIT
+
 This chapter contains a lot of information that is useful for improving your programming skills, however you are not required to learn all of it, and not required to memorize everything for the exam.
 
 You should be able to understand the fundamental concepts of classes and object-oriented programming (OOP) in Python as well as the key principles of encapsulation, inheritance, and polymorphism in OOP, which will enable you to better understand and use the classes that are everywhere in Python packages. For example, the class `rv_continuous` in `scipy.stats`, which is used for defining probability distributions, are used heavily in MUDE!

--- a/book/programming/week_1_8.md
+++ b/book/programming/week_1_8.md
@@ -1,13 +1,12 @@
-````{margin}
+# Week 1.8: SymPy
+
+% START-CREDIT
+% source: programming
 ```{attributiongrey} Attribution
 :class: attribution
-Written by [Tom van Woudenberg](https://github.com/TeachBooks/learn-python/commits/MUDE_book/book/08/sympy.ipynb)
-
-This chapter reuses CC BY content from {cite:t}`sympy`. {fa}`quote-left`[Find out more here](external_resources)
+This chapter reuses material from _Python for Engineers_. {ref}`Find out more here <programming_credit>`.
 ```
-````
-
-# Week 1.8: SymPy
+% END-CREDIT
 
 This week you'll learn how to use SymPy, a python package which does symbolical math for you!
 

--- a/book/propagation_uncertainty/00a_CovCorr.md
+++ b/book/propagation_uncertainty/00a_CovCorr.md
@@ -60,6 +60,14 @@ The interactive element below allows you to play around with the correlation val
 
 <iframe src="../_static/elements/element_correlation.html" width="600" height="400" frameborder="0"></iframe>
 
+% START-CREDIT
+% source: maxramgraber
+```{attributiongrey} Attribution
+:class: attribution
+This interactive figure is created by Max Ramgraber. {ref}`Find out more here <uncertainty_propagation_credit>`.
+```
+% END-CREDIT
+
 ### Covariance matrix
 
 When considering a random vector $X= [\begin{array}{llll} X_1 & X_2 & \ldots &X_m \end{array}]^T$, we can 'collect' all covariances in the so-called *covariance matrix*:
@@ -71,3 +79,11 @@ $$
 Note that the covariance matrix is symmetric, since $Cov(X_i,X_j)= Cov(X_j,X_i)$. 
 
 If all measurements are independent, all covariances will be equal to zero, and the covariance matrix becomes a diagonal matrix with the variances on the diagonal. 
+
+% START-CREDIT
+% source: uncertainty_propagation
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <uncertainty_propagation_credit>`.
+```
+% END-CREDIT

--- a/book/propagation_uncertainty/00a_CovCorr.md
+++ b/book/propagation_uncertainty/00a_CovCorr.md
@@ -58,15 +58,23 @@ Scatterplots of outcomes of ($X_1,X_2$) with different correlation coefficients.
 
 The interactive element below allows you to play around with the correlation value yourself. Observe how the distribution's density contours, or the scattered data, changes when you adapt the correlation value.
 
-<iframe src="../_static/elements/element_correlation.html" width="600" height="400" frameborder="0"></iframe>
-
 % START-CREDIT
 % source: maxramgraber
+
+````{margin}
 ```{attributiongrey} Attribution
 :class: attribution
 This interactive figure is created by Max Ramgraber. {ref}`Find out more here <uncertainty_propagation_credit>`.
 ```
+````
+
 % END-CREDIT
+
+````{iframe-figure} ../_static/elements/element_correlation.html
+:name: density_scatter_3
+
+Interactively change the correlation coefficient to visualize the effect on density contours or samples of the bivariate Gaussian distribution.
+````
 
 ### Covariance matrix
 
@@ -86,4 +94,5 @@ If all measurements are independent, all covariances will be equal to zero, and 
 :class: attribution
 This chapter was written by Sandra Verhagen. {ref}`Find out more here <uncertainty_propagation_credit>`.
 ```
+
 % END-CREDIT

--- a/book/propagation_uncertainty/00b_MultivariateNormal.ipynb
+++ b/book/propagation_uncertainty/00b_MultivariateNormal.ipynb
@@ -33,14 +33,25 @@
    "source": [
     "## Play with bivariate normal PDF\n",
     "\n",
-    "In this small demo you can create plots of the bivariate normal PDF, including a scatter plot of generated realizations, where you can play with the values of the mean, standard deviations and correlation coefficient. Adjust the values by dragging the handles for the mean (red), standard deviations (blue and yellow), and correlation (green) in the left subplot. Observe how the distribution changes, and how each parameter affects the covariance matrix."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<iframe src=\"../_static/elements/element_2D_Gaussian.html\" width=\"900\" height=\"300\" frameborder=\"0\"></iframe>"
+    "In this small demo you can create plots of the bivariate normal PDF, including a scatter plot of generated realizations, where you can play with the values of the mean, standard deviations and correlation coefficient. Adjust the values by dragging the handles for the mean (red), standard deviations (blue and yellow), and correlation (green) in the left subplot. Observe how the distribution changes, and how each parameter affects the covariance matrix.\n",
+    "\n",
+    "% START-CREDIT\n",
+    "% source: maxramgraber\n",
+    "````{margin}\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This interactive figure is created by Max Ramgraber. {ref}`Find out more here <distributions_credit>`.\n",
+    "```\n",
+    "````\n",
+    "% END-CREDIT\n",
+    "\n",
+    "````{iframe-figure} ../_static/elements/element_2D_Gaussian.html\n",
+    ":name: 2D_Gaussian\n",
+    ":height: 300\n",
+    ":width: 900\n",
+    "\n",
+    "Interactively change the means, standard deviations and correlation coefficient for the bivariate Gaussian PDF and visualize how the density contours, samples and covariance matrix change.\n",
+    "````"
    ]
   },
   {

--- a/book/propagation_uncertainty/00b_MultivariateNormal.ipynb
+++ b/book/propagation_uncertainty/00b_MultivariateNormal.ipynb
@@ -42,6 +42,19 @@
    "source": [
     "<iframe src=\"../_static/elements/element_2D_Gaussian.html\" width=\"900\" height=\"300\" frameborder=\"0\"></iframe>"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: uncertainty_propagation\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Sandra Verhagen. {ref}`Find out more here <uncertainty_propagation_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/propagation_uncertainty/01_ErrorPropagation.md
+++ b/book/propagation_uncertainty/01_ErrorPropagation.md
@@ -224,3 +224,11 @@ In this video the functions of $n$ random variables is discussed, as well as the
 
     <iframe width="560" height="315" src="https://www.youtube.com/embed/sRkjvpHTrBw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 ```
+
+% START-CREDIT
+% source: uncertainty_propagation
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <uncertainty_propagation_credit>`.
+```
+% END-CREDIT

--- a/book/propagation_uncertainty/02_LinearPropagation.md
+++ b/book/propagation_uncertainty/02_LinearPropagation.md
@@ -112,3 +112,11 @@ $$
 
 ```
 :::
+
+% START-CREDIT
+% source: uncertainty_propagation
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <uncertainty_propagation_credit>`.
+```
+% END-CREDIT

--- a/book/propagation_uncertainty/overview.md
+++ b/book/propagation_uncertainty/overview.md
@@ -1,6 +1,14 @@
 (01_errorprop)=
 # Propagation of Uncertainty
 
+% START-CREDIT
+% source: uncertainty_propagation
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <uncertainty_propagation_credit>`.
+```
+% END-CREDIT
+
 In engineering and sciences we often work with functions of random variables, since when estimating or modelling something, the output is a function of the random input variables, see {numref}`functions_RV`
 
 ```{figure} https://files.mude.citg.tudelft.nl/01_Functions.png

--- a/book/propagation_uncertainty/uncertainty.md
+++ b/book/propagation_uncertainty/uncertainty.md
@@ -1,3 +1,4 @@
+(uncertainty_classification)=
 # Uncertainty Classification
 
 All of us have an idea of what is uncertainty, but we may use different names for it: unpredictability, randomness, ambiguity, variability... Thus, we can say that something is uncertain if we don't know for sure (*not a big surprise, right?*).
@@ -27,3 +28,11 @@ Note that there is no universal uncertainty classification. You can read more ab
 [^ref1]: Der Kiureghian and Ditlevsen (2009). Aleatory or epistemic? Does it matter? *Structural safety* 31, 2, 105-112. https://doi.org/10.1016/j.strusafe.2008.06.020
 
 [^ref2]: Van Gelder (2000). Statistical methods for the risk-based design of civil structures. PhD thesis. TUDelft. http://resolver.tudelft.nl/uuid:6a62d6fa-cbcc-4c38-af8a-027c3d191a9d
+
+% START-CREDIT
+% source: uncertainty_propagation
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Sandra Verhagen. {ref}`Find out more here <uncertainty_propagation_credit>`.
+```
+% END-CREDIT

--- a/book/signal/dft.md
+++ b/book/signal/dft.md
@@ -113,6 +113,6 @@ Hence, *without* factors $\Delta t$ and $\frac{1}{\Delta t}$. This is also how D
 % source: signal_processing
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Christian Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+This chapter is written by Christian Tiberius. {ref}`Find out more here <signal_processing_credit>`.
 ```
 % END-CREDIT

--- a/book/signal/dft.md
+++ b/book/signal/dft.md
@@ -109,3 +109,10 @@ with both $k$ and $n\in\{0,1,...,N-1\}$
 
 Hence, *without* factors $\Delta t$ and $\frac{1}{\Delta t}$. This is also how DFT is implemented in programming languages like Matlab and Python; the user has to restore time and frequency dimension!
 
+% START-CREDIT
+% source: signal_processing
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Christian Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+```
+% END-CREDIT

--- a/book/signal/fourier_complex.md
+++ b/book/signal/fourier_complex.md
@@ -131,6 +131,6 @@ $\implies$ periodic signal written in terms of sum of cosines and sines, togethe
 % source: signal_processing
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+This chapter is written by Christiaan Tiberius. {ref}`Find out more here <signal_processing_credit>`.
 ```
 % END-CREDIT

--- a/book/signal/fourier_complex.md
+++ b/book/signal/fourier_complex.md
@@ -126,3 +126,11 @@ then, for real signals:
 * argument (or phase): $\theta_k=-\theta_{-k}$, **odd** function of $k$, forming **phase spectrum**
 
 $\implies$ periodic signal written in terms of sum of cosines and sines, together (pairwise) represented in complex exponentials
+
+% START-CREDIT
+% source: signal_processing
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+```
+% END-CREDIT

--- a/book/signal/fourier_nb.ipynb
+++ b/book/signal/fourier_nb.ipynb
@@ -7520,6 +7520,20 @@
    "source": [
     "We can observe that the created function becomes more like a square wave function as the number of terms (N) increases. So, a square wave function can be simulated by a sum of harmonically related sine functions."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "518205f7",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: signal_processing\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/signal/fourier_nb.ipynb
+++ b/book/signal/fourier_nb.ipynb
@@ -7530,7 +7530,7 @@
     "% source: signal_processing\n",
     "```{attributiongrey} Attribution\n",
     ":class: attribution\n",
-    "This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.\n",
+    "This chapter is written by Christiaan Tiberius. {ref}`Find out more here <signal_processing_credit>`.\n",
     "```\n",
     "% END-CREDIT"
    ]

--- a/book/signal/fourier_real.md
+++ b/book/signal/fourier_real.md
@@ -207,6 +207,6 @@ $$
 % source: signal_processing
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+This chapter is written by Christiaan Tiberius. {ref}`Find out more here <signal_processing_credit>`.
 ```
 % END-CREDIT

--- a/book/signal/fourier_real.md
+++ b/book/signal/fourier_real.md
@@ -1,3 +1,4 @@
+(fourier_real)=
 # Fourier Series
 
 Our goal in this chapter is to be able to express a periodic signal $x(t)$ as a sum of harmonically related cosines and sines
@@ -201,3 +202,11 @@ $$
 ````
 
 :::
+
+% START-CREDIT
+% source: signal_processing
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+```
+% END-CREDIT

--- a/book/signal/fourier_transf.md
+++ b/book/signal/fourier_transf.md
@@ -192,6 +192,6 @@ $$
 % source: signal_processing
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+This chapter is written by Christiaan Tiberius. {ref}`Find out more here <signal_processing_credit>`.
 ```
 % END-CREDIT

--- a/book/signal/fourier_transf.md
+++ b/book/signal/fourier_transf.md
@@ -187,3 +187,11 @@ $$
 ````
 
 :::
+
+% START-CREDIT
+% source: signal_processing
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+```
+% END-CREDIT

--- a/book/signal/intro.md
+++ b/book/signal/intro.md
@@ -5,7 +5,7 @@
 % source: signal_processing
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+This chapter is written by Christiaan Tiberius. {ref}`Find out more here <signal_processing_credit>`.
 ```
 % END-CREDIT
 

--- a/book/signal/intro.md
+++ b/book/signal/intro.md
@@ -1,5 +1,13 @@
-(SP)=
+(signal_processing)=
 # Signal Processing
+
+% START-CREDIT
+% source: signal_processing
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+```
+% END-CREDIT
 
 The goal of this week is to be able to identify and analyze frequency components in a signal; this is referred to as _spectral analysis._ The following chapters are told in a story-like sequence that will guide you through this process naturally.
 

--- a/book/signal/sampling.md
+++ b/book/signal/sampling.md
@@ -242,6 +242,6 @@ Given a signal $x(t)$ that is sampled at frequency $f_s$, what does $X_s(f)$ loo
 % source: signal_processing
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+This chapter is written by Christiaan Tiberius. {ref}`Find out more here <signal_processing_credit>`.
 ```
 % END-CREDIT

--- a/book/signal/sampling.md
+++ b/book/signal/sampling.md
@@ -237,3 +237,11 @@ To prevent aliases, this frequency $f_s$ should be larger than $2f_h$, where $f_
 Given a signal $x(t)$ that is sampled at frequency $f_s$, what does $X_s(f)$ look like? The following quiz questions will test your knowledge.
 
 <iframe src="https://tudelft.h5p.com/content/1292121772554459737/embed" aria-label="Sampling Quiz" width="1088" height="637" frameborder="0" allowfullscreen="allowfullscreen" allow="autoplay *; geolocation *; microphone *; camera *; midi *; encrypted-media *"></iframe><script src="https://tudelft.h5p.com/js/h5p-resizer.js" charset="UTF-8"></script>
+
+% START-CREDIT
+% source: signal_processing
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+```
+% END-CREDIT

--- a/book/signal/spectral_est.md
+++ b/book/signal/spectral_est.md
@@ -166,3 +166,11 @@ $$\begin{gather*}E=\lim_{T\to\infty}\int_{-T}^{T}|x(t)|^2dt\\ P=\lim_{T\to\infty
 Finally, we derived and gave a formal definition for **Parseval's theorem** which reads (for an a-periodic signal) as:
 
 $$E=\int_{-\infty}^{\infty}|x(t)|^2dt=\int_{-\infty}^{\infty}|X(f)|^2df$$
+
+% START-CREDIT
+% source: signal_processing
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+```
+% END-CREDIT

--- a/book/signal/spectral_est.md
+++ b/book/signal/spectral_est.md
@@ -171,6 +171,6 @@ $$E=\int_{-\infty}^{\infty}|x(t)|^2dt=\int_{-\infty}^{\infty}|X(f)|^2df$$
 % source: signal_processing
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+This chapter is written by Christiaan Tiberius. {ref}`Find out more here <signal_processing_credit>`.
 ```
 % END-CREDIT

--- a/book/signal/videos.md
+++ b/book/signal/videos.md
@@ -74,3 +74,11 @@ These videos overlap to some extent with the theory presented in the book, and a
 
     <iframe width="560" height="315" src="https://www.youtube.com/embed/q7diLuuvSRU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 ```
+
+% START-CREDIT
+% source: signal_processing
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+```
+% END-CREDIT

--- a/book/signal/videos.md
+++ b/book/signal/videos.md
@@ -79,6 +79,6 @@ These videos overlap to some extent with the theory presented in the book, and a
 % source: signal_processing
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Christiaan Tiberius. {fa}`quote-left`{ref}`Find out more here <signal_processing_credit>`.
+This chapter is written by Christiaan Tiberius. {ref}`Find out more here <signal_processing_credit>`.
 ```
 % END-CREDIT

--- a/book/time_series/acf.md
+++ b/book/time_series/acf.md
@@ -264,3 +264,11 @@ $$
 
 ```
 :::
+
+% START-CREDIT
+% source: time_series_analysis
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen. {ref}`Find out more here <time_series_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/time_series/ar.ipynb
+++ b/book/time_series/ar.ipynb
@@ -233,6 +233,19 @@
     "\n",
     "Where $\\mathrm{A}=\\begin{bmatrix}S_1 & S_2 & \\cdots & S_{m-1}\\end{bmatrix}^T$ and $S=\\begin{bmatrix}S_2 & S_3 & \\cdots & S_m\\end{bmatrix}^T$.\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: time_series_analysis\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen. {ref}`Find out more here <time_series_analysis_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/time_series/ar_exercise.ipynb
+++ b/book/time_series/ar_exercise.ipynb
@@ -473,6 +473,19 @@
     "print('Phi_2 = ', round(phi_ar2[1], 4), '+/-', round(1.96 * sigma_phi2[1], 4))\n",
     "\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: time_series_analysis\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen. {ref}`Find out more here <time_series_analysis_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/time_series/components.md
+++ b/book/time_series/components.md
@@ -44,7 +44,7 @@ The trend is the general pattern of the time series and shows its long-term chan
 :width: 600px
 :align: center
 
-Monthly time series of global mean sea level measurements using Satellite Altimetry technique. Source image: https://www.cmar.csiro.au/sealevel/sl_hist_last_decades.html
+Monthly time series of global mean sea level measurements using Satellite Altimetry technique. Source image: {cite:t}`csiro`.
 ```
 
 {numref}`trend` shows a positive trend (red line) of around $3.5$ mm/year, which in this case indicates sea level rise. This however needs to be further investigated and tested statistically (see {ref}`hypothesis_testing` and also {ref}`modelling_tsa`).
@@ -210,3 +210,11 @@ where
 - $u_k(t)$ is the Heaviside step function
 - $\epsilon(t)$ is the i.i.d. random Gaussian noise, i.e. $\epsilon(t) \sim \textbf{N}(0, \sigma^2)$.
 :::
+
+% START-CREDIT
+% source: time_series_analysis
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen. {ref}`Find out more here <time_series_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/time_series/exercise1.ipynb
+++ b/book/time_series/exercise1.ipynb
@@ -196,6 +196,19 @@
     "plt.xlabel('Time')\n",
     "plt.title('$Y(t) = 1 + 0.02 t + cos(0.02πt + 0.2π) + 5 u_{300}(t) + N(0,0.5^2)$');"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: time_series_analysis\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen. {ref}`Find out more here <time_series_analysis_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/time_series/exercises.md
+++ b/book/time_series/exercises.md
@@ -382,3 +382,11 @@ Which is a function of $\tau$, but not a function of time $t$. This shows that t
 
 ```
 :::
+
+% START-CREDIT
+% source: time_series_analysis
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen. {ref}`Find out more here <time_series_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/time_series/fit_BLUE.ipynb
+++ b/book/time_series/fit_BLUE.ipynb
@@ -358,6 +358,19 @@
     "plt.tight_layout()\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: time_series_analysis\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen. {ref}`Find out more here <time_series_analysis_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/time_series/forecasting.md
+++ b/book/time_series/forecasting.md
@@ -32,3 +32,10 @@ In summary, given a time series $Y=\mathrm{Ax}+\epsilon$, the workflow is as fol
 This procedure is a general approach to forecasting time series data. It resembles the process of stochastic inter- and extrapolation, which is used in many fields of science and engineering.
 ```
 
+% START-CREDIT
+% source: time_series_analysis
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen. {ref}`Find out more here <time_series_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/time_series/intro.md
+++ b/book/time_series/intro.md
@@ -1,4 +1,13 @@
+(tsa)=
 # Time Series Analysis 
+
+% START-CREDIT
+% source: time_series_analysis
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen. {ref}`Find out more here <time_series_analysis_credit>`.
+```
+% END-CREDIT
 
 In this chapter, we will first introduce the components to describe a time series: trend, signal, offsets, irregularities and noise. It will then be shown how to estimate the signal-of-interest (everything except noise).
 
@@ -9,5 +18,5 @@ Next, we will consider stationary time series, meaning that the statistical prop
 :width: 600px
 :align: center
 
-Recorded and expected global warming from 1960 to 2100, from IPCC report ([Masson-Delmotte, et al. (20219)](https://www.researchgate.net/profile/Peter-Marcotullio/publication/330090901_Sustainable_development_poverty_eradication_and_reducing_inequalities_In_Global_warming_of_15C_An_IPCC_Special_Report/links/6386062b48124c2bc68128da/Sustainable-development-poverty-eradication-and-reducing-inequalities-In-Global-warming-of-15C-An-IPCC-Special-Report.pdf))
+Recorded and expected global warming from 1960 to 2100, from {cite:t}`ipcc2018`.
 ```

--- a/book/time_series/intro_graph.ipynb
+++ b/book/time_series/intro_graph.ipynb
@@ -356,11 +356,17 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "% START-CREDIT\n",
+    "% source: time_series_analysis\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter was written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen. {ref}`Find out more here <time_series_analysis_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/time_series/modelling.md
+++ b/book/time_series/modelling.md
@@ -155,3 +155,11 @@ Left: time series (grey) and estimated linear trend and sine wave with period of
 This means we can estimate the frequency $\omega_0$ of the periodic pattern using the techniques discussed in the chapter on signal processing. Once we have the frequency, we can construct the design matrix $\mathrm{A}$. 
 
 It is also possible to infer the frequency of the periodic pattern by reasoning. For example, if we know our model depends on temperature, we can assume that the frequency of the seasonal pattern is related to the temperature cycle (e.g., 24 hours). However, this is a more qualitative approach and should be used with caution. Best practice is to use the DFT or PSD to estimate the frequency.
+
+% START-CREDIT
+% source: time_series_analysis
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen. {ref}`Find out more here <time_series_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/time_series/noise.ipynb
+++ b/book/time_series/noise.ipynb
@@ -139,7 +139,7 @@
               "version_minor": 0
             },
             "text/plain": [
-              "interactive(children=(Dropdown(description='Noise Type:', index=3, options=('Pink Noise', 'Red Noise', 'Blue N\u2026"
+              "interactive(children=(Dropdown(description='Noise Type:', index=3, options=('Pink Noise', 'Red Noise', 'Blue N…"
             ]
           },
           "execution_count": 2,
@@ -201,6 +201,19 @@
         "```{note}\n",
         "If you are interested, you can read more about the different types of noise in the [Wikipedia article](https://en.wikipedia.org/wiki/Colors_of_noise). In here you can also listen to the different types of noise, which might give you a better understanding of the differences.\n",
         "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "% START-CREDIT\n",
+        "% source: time_series_analysis\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter was written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen. {ref}`Find out more here <time_series_analysis_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
       ]
     }
   ],

--- a/book/time_series/stationarity.md
+++ b/book/time_series/stationarity.md
@@ -122,3 +122,11 @@ We have seen different ways of obtaining a stationary time series from the origi
 4. Predict the noise $\hat{\epsilon}_p$ based on the AR model.
 
 5. Predict future values of the time series: $\hat{Y}_p=\mathrm{A}_p\hat{X}+\hat{\epsilon}_p$ (Section [Forecasting](forecast)).
+
+% START-CREDIT
+% source: time_series_analysis
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen. {ref}`Find out more here <time_series_analysis_credit>`.
+```
+% END-CREDIT

--- a/book/time_series/types.md
+++ b/book/time_series/types.md
@@ -103,3 +103,11 @@ Estimating a state in the past and future is referred to as *smoothing* and *fil
 
 
 ![prediction](./figs/prediction.png "prediction")
+
+% START-CREDIT
+% source: time_series_analysis
+```{attributiongrey} Attribution
+:class: attribution
+This chapter was written by Alireza Amiri-Simkooei, Christiaan Tiberius and Sandra Verhagen. {ref}`Find out more here <time_series_analysis_credit>`.
+```
+% END-CREDIT

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ sphinx-inline-tabs
 sphinx-tudelft-theme
 sphinx-named-colors
 docutils == 0.17.1
+sphinx-iframes
 
 git+https://github.com/TeachBooks/Sphinx-Thebe


### PR DESCRIPTION
This PR is primarily meant to illustrate the changes made to the book in preparation for making the 2024-25 version open and archiving it. Work will proceed by using branches and PR's to update large chunks of the book at a time (e.g., one or more chapters, the credits page, etc).

If this PR is merged into the 2025 book, some commits should not be included. To make this easier, a new ruleset was created which:

1. requires changes to be made with PR's from another branch
2. requires merge commits to be squashed. this should make cherry picking easier, as the updates to the book can proceed chapter-by-chapter
3. MUDE MT Team can bypass rules

No extra GH review is required in the PR via the new branch ruleset, as this is already required by default for this repo.

_UPDATE:_ cherry picking is definitely going to be too much work. The commits listed below illustrate changes that should be manually reversed with new commits once `2024` is merged into `2025-draft`

Here is a list of commits that contain changes that should _not_ be included in the 2025 version of the book:
- d9c04acb5a152c78fbfc1bcdfb61c9265e7a1ecc (add language for 2024 book)
- 68faebdbb251a7896a97242fc3c4f80195569ebd (removes empty intro page)
