### PR TITLE
2024 Machine Learning credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Happy book building!
 ## Contact
 If you encounter any issues, report it by clicking the GitHub icon and lightbulb on the top right corner of this page. Or contribute directly by creating a pull request in the [repository](https://github.com/TUDelft-MUDE/book).
 
-If you have questions on the contact, contact the MUDE team at MUDE-CEG@tudelft.nl. If you've technical questions regarding this book, contact the IT-coordinator of MUDE (Tom): T.R.vanWoudenberg@tudelft.nl
+If you have questions on the content, contact the MUDE team at MUDE-CEG@tudelft.nl. If you have technical questions regarding this book, contact the IT-coordinator of MUDE (Tom): T.R.vanWoudenberg@tudelft.nl
 
 ## Additional Information
 

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -22,7 +22,7 @@ sphinx:
     thebe_config:
       use_thebe_lite: true
       exclude_patterns: []
-      exclude_patterns: ["**/*.JPG", "**/*.PNG", "**/*.bib", "**/*.cpg", "**/*.csv", "**/*.dbf", "**/*.geojson", "**/*.gif", "**/*.html", "**/*.ico", "**/*.ipynb", "**/*.jl", "**/*.jpeg", "**/*.jpg", "**/*.json", "**/*.md", "**/*.npy", "**/*.pdf", "**/*.png", "**/*.prj", "**/*.py", "**/*.sbn", "**/*.sbx", "**/*.shp", "**/*.shx", "**/*.svg", "**/*.tif", "**/*.tiff", "**/*.txt", "**/*.webp", "**/*.whl", "**/*.xlsx", "**/*.xml", "**/*.yml", "**/*.zip"]
+      exclude_patterns: ["**/*.JPG", "**/*.PNG", "**/*.bib", "**/*.cpg", "**/*.csv", "**/*.dbf", "**/*.geojson", "**/*.gif", "**/*.html", "**/*.ico", "**/*.ipynb", "**/*.jl", "**/*.jpeg", "**/*.jpg", "**/*.json", "**/*.md", "**/*.npy", "**/*.pdf", "**/*.png", "**/*.prj", "**/*.sbn", "**/*.sbx", "**/*.shp", "**/*.shx", "**/*.svg", "**/*.tif", "**/*.tiff", "**/*.txt", "**/*.webp", "**/*.whl", "**/*.xlsx", "**/*.xml", "**/*.yml", "**/*.zip"]
     html_theme_options:
       logo:
         text: CEGM1000 Modelling, Uncertainty, and Data for Engineers

--- a/book/_credits.yml
+++ b/book/_credits.yml
@@ -104,6 +104,7 @@ sources:
       - Anne Poot
       - Joep Storm
       - Leon Riccius
+    type: internal
 
   signal_processing:
     title: Signal Processing

--- a/book/credits.md
+++ b/book/credits.md
@@ -61,5 +61,12 @@ The following pages contain content written by others, part of which has been re
 
 Credits are described here and can be used in combination with the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
 
+(machine_learning_credit)=
+### Chapter: {doc}`machine_learning`
+
+> Chapter {doc}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
+>
+> This chapter is released under the CC BY license for this book, and can be cited as described above.
+
 > Chapter <title> is written by <authors>. Special thanks goes to <name> for <contribution>.
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -39,21 +39,20 @@ If an author is not listed on a particular page, it is by the Editors (for examp
 
 Auxiliary files such as figures, code, videos, etc, are included under the license of this book and should be attributed to the authors of the chapter or page where they are used, unless otherwise stated below or in the file itself. Text-based files (i.e., non-binary) are typically stored in the repository, within the subdirectory where the source file of the chapter or page is located. Binary files are stored in an FTP server (`https://files.mude.citg.tudelft.nl/<binary_file_name>`). Videos and quiz questions are stored in and served from YouTube and H5p; contact the MUDE Team directly if you are interested in source materials for these resources.
 
-(not_cc_by)=
+(credits_not_cc_by)=
 ### Resources _not_ under CC BY
 
 CC BY conditions are _not_ applicable to some resources included in this book which resources cannot be reused without explicit permission from the original copyright holder. These resources are listed individually within the summary of each chapter or page.
 
+(internal_resources)=
 ## Individual Chapters and Pages
 
-Credits are described here and can be used in combination with the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
+Credits are provided here for chapters and pages that are released under the license of this book (internal resources). Use the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
 
 (machine_learning_credit)=
 ### Chapter: {ref}`machine_learning`
 
 > Chapter {ref}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
->
-> This chapter is released under the license for this book, and can be cited as described above.
 
 > Chapter `<title>` is written by `<authors>`. Special thanks goes to `<name>` for `<contribution>`.
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -50,7 +50,11 @@ CC BY conditions are _not_ applicable to some resources included in this book wh
 Credits are provided here for chapters and pages that are released under the license of this book (internal resources). Use the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
 
 (machine_learning_credit)=
-### Chapter: {ref}`machine_learning`
+### Chapter: Machine Learning
+% CREDIT-NOTE: note that the title ref is not included because
+%   the tag is displayed in the rhs toc.
+% Future dev may use templating to automatically include the
+%   right text in these sections
 
 > Chapter {ref}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -62,9 +62,9 @@ The following pages contain content written by others, part of which has been re
 Credits are described here and can be used in combination with the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
 
 (machine_learning_credit)=
-### Chapter: {doc}`machine_learning`
+### Chapter: {ref}`machine_learning`
 
-> Chapter {doc}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
+> Chapter {ref}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
 >
 > This chapter is released under the CC BY license for this book, and can be cited as described above.
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -40,12 +40,25 @@ If an author is not listed on a particular page, it is by the Editors (for examp
 Auxiliary files such as figures, code, videos, etc, are included under the license of this book and should be attributed to the authors of the chapter or page where they are used, unless otherwise stated below or in the file itself. Text-based files (i.e., non-binary) are typically stored in the repository, within the subdirectory where the source file of the chapter or page is located. Binary files are stored in an FTP server (`https://files.mude.citg.tudelft.nl/<binary_file_name>`). Videos and quiz questions are stored in and served from YouTube and H5p; contact the MUDE Team directly if you are interested in source materials for these resources.
 
 (not_cc_by)=
-### Resources not under CC BY
+### Resources _not_ under CC BY
 
 CC BY conditions are _not_ applicable to some resources included in this book which resources cannot be reused without explicit permission from the original copyright holder. These resources are listed individually within the summary of each chapter or page.
 
+## Individual Chapters and Pages
+
+Credits are described here and can be used in combination with the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
+
+(machine_learning_credit)=
+### Chapter: {ref}`machine_learning`
+
+> Chapter {ref}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
+>
+> This chapter is released under the license for this book, and can be cited as described above.
+
+> Chapter `<title>` is written by `<authors>`. Special thanks goes to `<name>` for `<contribution>`.
+
 (external_resources)=
-### External resources
+## External resources
 
 Parts of this book are taken from other external resources and reused in various ways. 
 
@@ -58,19 +71,6 @@ The following chapters/pages are included directly from an external resource and
 The following pages contain content written by others, part of which has been reused and/or modified by MUDE authors:
 - Pages REFERENCE and REFERENCE include text from CITATION that is used EXPLANATION. Original content licensed under CC BY. 
 - more as needed
-
-## Individual Chapters and Pages
-
-Credits are described here and can be used in combination with the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
-
-(machine_learning_credit)=
-### Chapter - {ref}`machine_learning`
-
-> Chapter {ref}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
->
-> This chapter is released under the license for this book, and can be cited as described above.
-
-> Chapter <title> is written by <authors>. Special thanks goes to <name> for <contribution>.
 
 ## Contact
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -64,8 +64,6 @@ The following pages contain content written by others, part of which has been re
 Credits are described here and can be used in combination with the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
 
 (machine_learning_credit)=
-### Chapter: {ref}`machine_learning`
-
 > Chapter {ref}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
 >
 > This chapter is released under the license for this book, and can be cited as described above.

--- a/book/credits.md
+++ b/book/credits.md
@@ -37,6 +37,8 @@ This manual is [CC BY 4.0 licensed](https://creativecommons.org/licenses/by/4.0/
 
 If an author is not listed on a particular page, it is by the Editors (for example, the introduction page of some chapters).
 
+Auxiliary files such as figures, code, etc, are included under the license of this book and should be attributed to the authors of the chapter or page where they are used, unless otherwise stated below or in the file itself. Text-based files (i.e., non-binary) are typically stored in the repository, within the subdirectory where the source file of the chapter or page is located. Binary files are stored in an FTP server (`https://files.mude.citg.tudelft.nl/<binary_file_name>`).
+
 (not_cc_by)=
 ### Resources not under CC BY
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -39,6 +39,11 @@ If an author is not listed on a particular page, it is by the Editors (for examp
 
 Auxiliary files such as figures, code, videos, etc, are included under the license of this book and should be attributed to the authors of the chapter or page where they are used, unless otherwise stated below or in the file itself. Text-based files (i.e., non-binary) are typically stored in the repository, within the subdirectory where the source file of the chapter or page is located. Binary files are stored in an FTP server (`https://files.mude.citg.tudelft.nl/<binary_file_name>`). Videos and quiz questions are stored in and served from YouTube and H5p; contact the MUDE Team directly if you are interested in source materials for these resources.
 
+(external_resources)=
+### External Resources
+
+Parts of this book are taken from other external resources and reused in various ways. Entire chapters or pages are listed individually in the {ref}`external_resources` section below. Resources that are used _within_ a page and/or are modified by MUDE authors are listed individually in the {ref}`internal_resources` section below.
+
 (credits_not_cc_by)=
 ### Resources _not_ under CC BY
 
@@ -56,24 +61,51 @@ Credits are provided here for chapters and pages that are released under the lic
 % Future dev may use templating to automatically include the
 %   right text in these sections
 
-> Chapter {ref}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
+> {ref}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
 
-> Chapter `<title>` is written by `<authors>`. Special thanks goes to `<name>` for `<contribution>`.
+(generic_credit)=
+### `<resource_type>`: `<title>`
 
-(external_resources)=
+> `<title>` is written by `<authors>`.
+> 
+> Special thanks goes to `<name>` for `<contribution>`.
+>
+> _or_
+>
+> Special thanks goes to:
+>  - `<name>` for `<contribution>`
+>  - `<name>` for `<contribution>`.
+>
+> Note: `<note-public>`
+>
+> The following resources are used in this `<resource_type>` but are _not_ included under the CC BY license of this book and cannot be reused without explicit permission from the original copyright holder:
+> - `resource_type>` `<resource>` is used in `<page>` (not modified). Original content licensed under `<license>`.
+> - `resource_type>` `<resource>` is used in `<page>` and `<modification>`. Original content licensed under `<license>`.
+> - `resource_type>` `<resource>` (`<bibtex>`) is used in `<page>` (unmodified). Original content licensed under `<license>` and is available `<resource_location>`.
+> - ...
+> 
+
+(external_resources_credits)=
 ## External resources
 
-Parts of this book are taken from other external resources and reused in various ways. 
+The following chapters and pages are included directly from an external resource, are not included under the CC BY license of this book and cannot be reused without explicit permission from the original copyright holder. Unless otherwise noted below, the contents have not been edited by the authors of this book.
 
-The following chapters/pages are included directly from an external resource and is not edited by MUDE authors:
+(finite_element_method_credit)=
+### Chapter: Introduction to Finite Elements
+
+> _WIP_
+
+### Programming Chapters
+
+> Programming Chapters REFERENCE are from CITATION/LINK. Original content licensed under CC BY.
+
+### Individual External Pages
+
+The pages listed here are not 
 
 - page [](./external/learn-python/book/08/sympy.ipynb). Original content licensed under CC BY.
-- Programming Chapters REFERENCE are from CITATION/LINK. Original content licensed under CC BY.
 - Page REFERENCE are from CITATION/LINK. Original content licensed under CC BY.
 
-The following pages contain content written by others, part of which has been reused and/or modified by MUDE authors:
-- Pages REFERENCE and REFERENCE include text from CITATION that is used EXPLANATION. Original content licensed under CC BY. 
-- more as needed
 
 ## Contact
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -23,18 +23,9 @@ This book is created using open source tools: it is a Jupyter Book that uses a n
 
 ## Acknowledgements
 
-This book has many contributors, many of whom are also key members of the MUDE Team:
+This book has many contributors, many of whom are also key members of the MUDE Team, as well as critical feedback from MUDE students. The sections below list the primary authors and contributors for each chapter, buit is unfortunately not possible to list all of the small contributions from various people from within and outside Delft University of Technology, not list all contributions in detail.
 
-- xxx
-- yyy
-- zzz
-- MUDE students 
-
-All from Delft University of Technology.
-
-This doesn't include small contributions from various people from within and outside Delft University of Technology.
-
-A better way to see the contributions is to check the [Contributors Page](https://github.com/TUDelft-MUDE/book/graphs/contributors) of the GitHub repository.
+A  better way to see the contributions is to check the [Contributors Page](https://github.com/TUDelft-MUDE/book/graphs/contributors) of the GitHub repository.
 
 A big "thank you" is also due to the Educational Management Team of the Civil Engineering and Geosciences Faculty at Delft University of Technology for giving the MUDE Team financial and organizational support during the early years of MUDE (especially 2022-2024), in particular Hans Welleman, Director of Education of the faculty. Without the freedom and support to experiment with new tools, this book (and [TeachBooks](https://teachbooks.io/) as well!) would not exist!
 
@@ -44,18 +35,17 @@ And in the end, none of this would have happened if it weren't for the quick mee
 
 This manual is [CC BY 4.0 licensed](https://creativecommons.org/licenses/by/4.0/) allowing you to share and adapt the material, as long as the source is named. Resources that are _not_ included under the CC BY license and external resources that are reused in this book are listed in the sections below.
 
+If an author is not listed on a particular page, it is by the Editors (for example, the introduction page of some chapters).
+
 (not_cc_by)=
 ### Resources not under CC BY
 
-CC BY conditions are not applicable to the following resources included in this book. These resources cannot be reused without explicit permission from the original copyright holder.
-
-In chapter CHAPTER:
-- RESOURCE
+CC BY conditions are _not_ applicable to some resources included in this book which resources cannot be reused without explicit permission from the original copyright holder. These resources are listed individually within the summary of each chapter or page.
 
 (external_resources)=
 ### External resources
 
-Parts of this book are taken from other external resources and reused in various ways. If an author is not listed on a particular page, it is by the Editors, except as follows:
+Parts of this book are taken from other external resources and reused in various ways. 
 
 The following chapters/pages are included directly from an external resource and is not edited by MUDE authors:
 
@@ -67,6 +57,9 @@ The following pages contain content written by others, part of which has been re
 - Pages REFERENCE and REFERENCE include text from CITATION that is used EXPLANATION. Original content licensed under CC BY. 
 - more as needed
 
+## Individual Chapters and Pages
 
+Credits are described here and can be used in combination with the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
 
+> Chapter <title> is written by <authors>. Special thanks goes to <name> for <contribution>.
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -64,6 +64,8 @@ The following pages contain content written by others, part of which has been re
 Credits are described here and can be used in combination with the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
 
 (machine_learning_credit)=
+### Chapter: Machine Learning
+
 > Chapter {ref}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
 >
 > This chapter is released under the license for this book, and can be cited as described above.

--- a/book/credits.md
+++ b/book/credits.md
@@ -50,7 +50,7 @@ CC BY conditions are _not_ applicable to some resources included in this book wh
 Credits are provided here for chapters and pages that are released under the license of this book (internal resources). Use the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
 
 (machine_learning_credit)=
-### Chapter: Machine Learning
+### Chapter: Introduction to Machine Learning
 % CREDIT-NOTE: note that the title ref is not included because
 %   the tag is displayed in the rhs toc.
 % Future dev may use templating to automatically include the

--- a/book/credits.md
+++ b/book/credits.md
@@ -37,7 +37,7 @@ This manual is [CC BY 4.0 licensed](https://creativecommons.org/licenses/by/4.0/
 
 If an author is not listed on a particular page, it is by the Editors (for example, the introduction page of some chapters).
 
-Auxiliary files such as figures, code, etc, are included under the license of this book and should be attributed to the authors of the chapter or page where they are used, unless otherwise stated below or in the file itself. Text-based files (i.e., non-binary) are typically stored in the repository, within the subdirectory where the source file of the chapter or page is located. Binary files are stored in an FTP server (`https://files.mude.citg.tudelft.nl/<binary_file_name>`).
+Auxiliary files such as figures, code, videos, etc, are included under the license of this book and should be attributed to the authors of the chapter or page where they are used, unless otherwise stated below or in the file itself. Text-based files (i.e., non-binary) are typically stored in the repository, within the subdirectory where the source file of the chapter or page is located. Binary files are stored in an FTP server (`https://files.mude.citg.tudelft.nl/<binary_file_name>`). Videos and quiz questions are stored in and served from YouTube and H5p; contact the MUDE Team directly if you are interested in source materials for these resources.
 
 (not_cc_by)=
 ### Resources not under CC BY
@@ -72,3 +72,6 @@ Credits are described here and can be used in combination with the guidance prov
 
 > Chapter <title> is written by <authors>. Special thanks goes to <name> for <contribution>.
 
+## Contact
+
+If you have questions on the content, contact the MUDE team at MUDE-CEG@tudelft.nl. If you have technical questions regarding this book, contact the IT-coordinator of MUDE (Tom): T.R.vanWoudenberg@tudelft.nl

--- a/book/credits.md
+++ b/book/credits.md
@@ -68,7 +68,7 @@ Credits are described here and can be used in combination with the guidance prov
 
 > Chapter {ref}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
 >
-> This chapter is released under the CC BY license for this book, and can be cited as described above.
+> This chapter is released under the license for this book, and can be cited as described above.
 
 > Chapter <title> is written by <authors>. Special thanks goes to <name> for <contribution>.
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -64,7 +64,7 @@ The following pages contain content written by others, part of which has been re
 Credits are described here and can be used in combination with the guidance provided above to properly share, reuse and cite relevant chapters, pages or any other resources from this book.
 
 (machine_learning_credit)=
-### Chapter: Machine Learning
+### Chapter - {ref}`machine_learning`
 
 > Chapter {ref}`machine_learning` is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
 >

--- a/book/ml/decision_theory_interactive.ipynb
+++ b/book/ml/decision_theory_interactive.ipynb
@@ -465,6 +465,20 @@
         "\n",
         "So far, we have looked at our k-nearest neighbors regressor, which is relatively easy to understand and play around with. However, this method is not often used in practice, as it scales poorly for large datasets. Furthermore, computing the closest points becomes computationally expensive when considering multiple inputs (high dimensions). In a limited data setting, taking the average of the nearest neighbors will often lead to poor performance. k-nearest neighbors is also sensitive to outliers. In the following chapter, we will apply what we have learned to a different model, namely, linear regression."
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ebcbde7a",
+      "metadata": {},
+      "source": [
+        "% START-CREDIT\n",
+        "% source: machine_learning\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/ml/knn_interactive.ipynb
+++ b/book/ml/knn_interactive.ipynb
@@ -375,6 +375,20 @@
         "## Final remarks\n",
         "So far, we have looked at our k-nearest neighbors regressor mostly qualitatively. However, it is possible to apply a more quantitative framework to our model and find the optimal value for $k$ in a more structured way. The following video and accompanying chapter will discuss how this is done. See you there!"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "dd7bfdc2",
+      "metadata": {},
+      "source": [
+        "% START-CREDIT\n",
+        "% source: machine_learning\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/ml/linear_models_interactive.ipynb
+++ b/book/ml/linear_models_interactive.ipynb
@@ -1331,9 +1331,17 @@
     },
     {
       "cell_type": "markdown",
-      "id": "4dc7cf29",
+      "id": "09613782",
       "metadata": {},
-      "source": []
+      "source": [
+        "% START-CREDIT\n",
+        "% source: machine_learning\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/ml/mude_tools.py
+++ b/book/ml/mude_tools.py
@@ -1,3 +1,13 @@
+# START-CREDIT
+# source: machine_learning
+#
+# This file is released under the license for the MUDE Book:
+#   https://github.com/TUDelft-MUDE/book
+# Authors: Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius.
+#
+# See the Credits section of the book additional information.
+# END-CREDIT
+
 # Import necessary packages
 import numpy as np
 import matplotlib.pyplot as plt

--- a/book/ml/nn_interactive.ipynb
+++ b/book/ml/nn_interactive.ipynb
@@ -621,6 +621,20 @@
         "\n",
         "In these videos you have seen a non-parametric model, namely k-nearest neighbours, and have learned about the bias-variance trade-off. Linear regression was shown as a parametric model that is linear in its parameters and has a closed form solution. Ridge regression has been introduced to prevent overfitting. Stochastic gradient descent has been shown as a way to train a model in an iterative fashion. In this final chapter, we explored a model with a nonlinear dependence on its parameters. You now understand the underlying principles of a broad set machine learning techniques, and know how to distinguish naive curve fitting from extracting (or learning) the relevant trends and patterns in data."
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "adec1f79",
+      "metadata": {},
+      "source": [
+        "% START-CREDIT\n",
+        "% source: machine_learning\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/ml/overview.md
+++ b/book/ml/overview.md
@@ -3,12 +3,10 @@
 
 % START-CREDIT
 % source: machine_learning
-````{margin}
 ```{attributiongrey} Attribution
 :class: attribution
-This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`
+This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.
 ```
-````
 % END-CREDIT
 
 _Machine learning_ is a set of techniques that uses computer algorithms to fit the parameters of a model. In the context of MUDE, it is a set of data-driven modelling techniques, closely related to the methods used in observation theory. However, whereas in observation theory we constructed the design matrix ourselves, based on some physics-based knowledge of the system of interest, in machine learning applications, we allow the algorithm more freedom to build (and refine) the model. Although this comes at the cost of less control over model parameters (the "unknowns" from observation theory) and increased complexity, the benefit is a more flexible model that is capable of capturing key characteristics of the problem at hand. For example, a neural network can be defined using thousands of weights (model parameters); far more than we can create with more "hands-on" techniques!

--- a/book/ml/overview.md
+++ b/book/ml/overview.md
@@ -1,4 +1,15 @@
+(machine_learning)=
 # Introduction to Machine Learning
+
+% START-CREDIT
+% source: machine_learning
+````{margin}
+```{attributiongrey} Attribution
+:class: attribution
+This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`
+```
+````
+% END-CREDIT
 
 _Machine learning_ is a set of techniques that uses computer algorithms to fit the parameters of a model. In the context of MUDE, it is a set of data-driven modelling techniques, closely related to the methods used in observation theory. However, whereas in observation theory we constructed the design matrix ourselves, based on some physics-based knowledge of the system of interest, in machine learning applications, we allow the algorithm more freedom to build (and refine) the model. Although this comes at the cost of less control over model parameters (the "unknowns" from observation theory) and increased complexity, the benefit is a more flexible model that is capable of capturing key characteristics of the problem at hand. For example, a neural network can be defined using thousands of weights (model parameters); far more than we can create with more "hands-on" techniques!
 

--- a/book/ml/review.ipynb
+++ b/book/ml/review.ipynb
@@ -35,6 +35,20 @@
     "````\n",
     "`````"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bf8722e",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: machine_learning\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {

--- a/book/ml/ridge_sgd_interactive.ipynb
+++ b/book/ml/ridge_sgd_interactive.ipynb
@@ -381,6 +381,20 @@
       "metadata": {},
       "outputs": [],
       "source": []
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d66a05ba",
+      "metadata": {},
+      "source": [
+        "% START-CREDIT\n",
+        "% source: machine_learning\n",
+        "```{attributiongrey} Attribution\n",
+        ":class: attribution\n",
+        "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+        "```\n",
+        "% END-CREDIT"
+      ]
     }
   ],
   "metadata": {

--- a/book/ml/teach_interactive.ipynb
+++ b/book/ml/teach_interactive.ipynb
@@ -279,6 +279,20 @@
    "source": [
     "plot3 = get_plot3()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e03119e4",
+   "metadata": {},
+   "source": [
+    "% START-CREDIT\n",
+    "% source: machine_learning\n",
+    "```{attributiongrey} Attribution\n",
+    ":class: attribution\n",
+    "This chapter is written by Iuri Rocha, Anne Poot, Joep Storm and Leon Riccius. {fa}`quote-left`{ref}`Find out more here <machine_learning_credit>`.\n",
+    "```\n",
+    "% END-CREDIT"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
first chapter to have "everything" (manually) added to content in the 2024 book
also includes changes to the credits page (these commits will still be squashed, as the changes for ML specifically should also be included in the 2025 book).