### PR TITLE
Add references and credits for adjustment and testing theory

### DIFF
--- a/book/_bibliography/references.bib
+++ b/book/_bibliography/references.bib
@@ -478,3 +478,17 @@ M. Tignor, and T. Waterfield (eds.)]. Accessed 2024 at {{https://www.researchgat
 	year = {2024},
 	note = {[Accessed 12-2024]},
 }
+
+@misc{adjustment_thoery,
+  title={Adjustment thoery: an introduction},
+  author={Teunissen, Peter J.G.},
+  url={https://doi.org/10.59490/tb.95},
+	year = {2024},
+}
+
+@misc{testing_thoery,
+  title={Testing thoery: an introduction},
+  author={Teunissen, Peter J.G.},
+  url={https://doi.org/10.59490/tb.96},
+	year = {2024},
+}

--- a/book/_bibliography/references.bib
+++ b/book/_bibliography/references.bib
@@ -479,7 +479,7 @@ M. Tignor, and T. Waterfield (eds.)]. Accessed 2024 at {{https://www.researchgat
 	note = {[Accessed 12-2024]},
 }
 
-@misc{adjustment_thoery,
+@misc{adjustment_theory,
   title={Adjustment thoery: an introduction},
   author={Teunissen, Peter J.G.},
   url={https://doi.org/10.59490/tb.95},

--- a/book/_bibliography/references.bib
+++ b/book/_bibliography/references.bib
@@ -486,7 +486,7 @@ M. Tignor, and T. Waterfield (eds.)]. Accessed 2024 at {{https://www.researchgat
 	year = {2024},
 }
 
-@misc{testing_thoery,
+@misc{testing_theory,
   title={Testing thoery: an introduction},
   author={Teunissen, Peter J.G.},
   url={https://doi.org/10.59490/tb.96},

--- a/book/credits.md
+++ b/book/credits.md
@@ -80,7 +80,7 @@ Credits are provided here for chapters and pages that are released under the lic
 >
 > Special thanks goes to:
 > - Peter Teunissen and Christiaan Tiberius who co-shaped the material, indirectly, through collaboration with the author as TU Delft colleagues.
-> - The book _Adjustment theory: an introduction_ {cite:p}`adjustment_thoery` and _Testing theory: an introduction_ {cite:p}`testing_theory` which provided the framework for this chapter.
+> - The book _Adjustment theory: an introduction_ {cite:p}`adjustment_theory` and _Testing theory: an introduction_ {cite:p}`testing_theory` which provided the framework for this chapter.
 > - Sophie Keemink, Caspar Jungbacker and Thirza Feenstra, who provided feedback and helped develop exercises.
 
 (numerical_modelling_credit)=

--- a/book/credits.md
+++ b/book/credits.md
@@ -80,6 +80,7 @@ Credits are provided here for chapters and pages that are released under the lic
 >
 > Special thanks goes to:
 > - Peter Teunissen and Christiaan Tiberius who co-shaped the material, indirectly, through collaboration with the author as TU Delft colleagues.
+> - The book _Adjustment theory: an introduction_ {cite:p}`adjustment_thoery` and _Testing theory: an introductino_ {cite:p}`testing_theory` which provided the framework for this chapter.
 > - Sophie Keemink, Caspar Jungbacker and Thirza Feenstra, who provided feedback and helped develop exercises.
 
 (numerical_modelling_credit)=

--- a/book/credits.md
+++ b/book/credits.md
@@ -80,7 +80,7 @@ Credits are provided here for chapters and pages that are released under the lic
 >
 > Special thanks goes to:
 > - Peter Teunissen and Christiaan Tiberius who co-shaped the material, indirectly, through collaboration with the author as TU Delft colleagues.
-> - The book _Adjustment theory: an introduction_ {cite:p}`adjustment_thoery` and _Testing theory: an introductino_ {cite:p}`testing_theory` which provided the framework for this chapter.
+> - The book _Adjustment theory: an introduction_ {cite:p}`adjustment_thoery` and _Testing theory: an introduction_ {cite:p}`testing_theory` which provided the framework for this chapter.
 > - Sophie Keemink, Caspar Jungbacker and Thirza Feenstra, who provided feedback and helped develop exercises.
 
 (numerical_modelling_credit)=


### PR DESCRIPTION
Added two new bibliography entries for 'Adjustment theory: an introduction' and 'Testing theory: an introduction' by Peter J.G. Teunissen. Updated credits to acknowledge these works as providing the framework for the relevant chapter.