### PR TITLE
Updating week 1.4 edits to summary page

### DIFF
--- a/book/univariate_distributions/parameterization.ipynb
+++ b/book/univariate_distributions/parameterization.ipynb
@@ -93,7 +93,7 @@
         "\n",
         "```{figure} https://files.mude.citg.tudelft.nl/scipy.png\n",
         "---\n",
-        "scale: 80%\n",
+        "scale: 60%\n",
         "---\n",
         "Screenshot of the [Lognormal PDF from `scipy` stats](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.lognorm.html).\n",
         "```"

--- a/book/univariate_distributions/parameterization.ipynb
+++ b/book/univariate_distributions/parameterization.ipynb
@@ -7,7 +7,7 @@
       "source": [
         "# Location, Shape and Scale: Consistent Parameterization\n",
         "\n",
-        "In the previous sections, you have studied different parametric distributions that can be applied to model the univariate uncertainty in our data. Those distributions were characterized by a set of parameters (e.g.: $\\lambda$ for Exponential distribution), which can be fitted to model real-world data as accurately as possible and, thus, use the distribution for predicting future events. Along the sections devoted to present a selection of distribution functions, the equations for the PDF and CDF as you can usually find them in text books were presented. However, they are just equations! That means that we can play with them and parameterize the distribution a way that fits best to our purposes.\n",
+        "In the previous sections, you have studied different parametric distributions that can be applied to model the univariate uncertainty in our data. Those distributions were characterized by a set of parameters (e.g.: $\\lambda$ for Exponential distribution), which can be fitted to model real-world data as accurately as possible and, thus, use the distribution for predicting future events. On the {ref}`distribution summary page <./summary>`), a selection of distribution functions (i.e., the equations for the PDF and CDF) were presented. However, they are just equations! That means that we can reformulate them and parameterize the distribution in a way that best fits our purposes.\n",
         "\n",
         "In this section the parameterization **location**, **scale** and **shape** will be addressed in the context of `scipy` Python package (typically abbreviated `loc` `scale` and `shape`). This parameterization is very convenient due to the consistency it provides (all distributions use the same parameters and notation), the ease of the interpretation of those parameters and the advantages of their implementation in computer code. That is why `scipy` package (between others) uses this parameterization for continuous distribution functions."
       ]
@@ -87,15 +87,16 @@
       "source": [
         "## From convention to loc-scale-shape parameterization with an example\n",
         "\n",
-        "As mentioned, we have to be able to go from the parameters of the conventional form of the distribution to loc-shape-scale in order to use computer packages. Here, we will focus on Python's `scipy` library and will address the example of the Lognormal distribution, as this distribution is often the one that creates the most confusion. You can find the documentation about the Lognormal distribution in `scipy` [here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.lognorm.html).\n",
+        "As described above, we have to be able to go from the parameters of the conventional form of the distribution (e.g., those on the {ref}`distribution summary page <./summary>`), to loc-shape-scale in order to use computer packages. Here, we will focus on Python's `scipy` library and address the Lognormal distribution, as this distribution is often the one that creates the most confusion. You can find the documentation about the Lognormal distribution in `scipy` [here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.lognorm.html).\n",
         "\n",
-        "If you follow the link, you will find the following description of the implemented Lognormal distribution:\n",
+        "If you follow the documentation link, you will find the following description of the implemented Lognormal distribution:\n",
         "\n",
         "```{figure} https://files.mude.citg.tudelft.nl/scipy.png\n",
-        "\n",
-        "Documentation on the Lognormal distribution in `scipy`.\n",
-        "```\n",
-        "\n"
+        "---\n",
+        "scale: 80%\n",
+        "---\n",
+        "Screenshot of the [Lognormal PDF from `scipy` stats](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.lognorm.html).\n",
+        "```"
       ]
     },
     {
@@ -103,7 +104,7 @@
       "id": "0246b9f9",
       "metadata": {},
       "source": [
-        "First, the PDF in standardized form is presented with a shape parameter $s$. Let's compare this PDF with the conventional one, which is given by\n",
+        "First, the PDF in standardized form is presented with a shape parameter $s$. Let's compare this PDF with the conventional one (from our {ref}`summary page <./summary>`), which is given by\n",
         "\n",
         "$$\n",
         "f(x) = \\frac{1}{x \\sigma \\sqrt{2 \\pi}}e^{\\left(\\normalsize -\\cfrac{(\\ln(x)-\\mu)^2}{2\\sigma^2}\\right)} \\tag{1}\n",

--- a/book/univariate_distributions/summary.md
+++ b/book/univariate_distributions/summary.md
@@ -177,43 +177,6 @@ Below, we will list the equations for the PDF, CDF, mean, and variance for the p
   - $\begin{array}{ll} E[X] = \frac{\alpha}{\alpha + \beta} \\ Var[X] = \frac{\alpha\beta}{(\alpha + \beta)^2(\alpha+\beta+1)}  \end{array}$
 ```
 
-
-```{list-table}
-:header-rows: 1
-
-* - Distribution
-  - PDF
-  - CDF
-  - Mean and variance
-* - Normal/Gaussian
-  - $f(x) = \cfrac{1}{\sigma \sqrt{2\pi}}e^{\left(\normalsize-\cfrac{(x-\mu)^2}{2\sigma^2}\right)}$
-  - $F(x) = \cfrac{1}{2}\left(1+\text{erf}\left(\cfrac{x-\mu}{\sigma\sqrt{2}}\right)\right)$
-  - $\begin{array}{ll} E[X] = \mu \\ Var[X] = \sigma^2  \end{array}$
-* - Uniform
-  - $\displaystyle f(x) = \begin{cases}\cfrac{1}{b-a} & \text{for }x \in [a,b] \\ 0 & \text{otherwise} \end{cases}$
-  - $F(x)=\begin{cases}0 & \text{for } x<a \\ \cfrac{x-a}{b-a} & \text{for } x\in[a,b] 1 & \text{for } x>b\end{cases}$
-  - $\begin{array}{ll} E[X]=\frac{1}{2}(a+b) \\ Var[X]=\frac{1}{12}(b-a)^2 \end{array}$ 
-* - Exponential
-  - $f(x) = \lambda e^{\normalsize-\lambda x}$
-  - $F(x) = 1 - e^{\normalsize-\lambda x}$
-  - $\begin{array}{ll} E[X] = \cfrac{1}{\lambda} \\ Var[X] = \cfrac{1}{\lambda^2} \end{array}$
-* - Beta
-  - $f(x) = \frac{x^{\alpha - 1} (1 - x)^{\beta - 1}}{B(\alpha, \beta)}$
-  - $F(x; \alpha, \beta) = \frac{1}{B(\alpha, \beta)} \int_0^x t^{\alpha - 1} (1 - t)^{\beta - 1} dt$
-  - $\begin{array}{ll} E[X] = \frac{\alpha}{\alpha + \beta} \\ Var[X] = \frac{\alpha\beta}{(\alpha + \beta)^2(\alpha+\beta+1)}  \end{array}$
-* - Gumbel
-  - $f(x) = \cfrac{1}{\beta} e^{\normalsize-\left(z + e^{\normalsize-z}\right)}\text{, where }z=\cfrac{x-\alpha}{\beta}$
-  - $F(x)=e^{\normalsize-e^{\normalsize-z}}$
-  - $\begin{array}{ll} E[X] = \alpha + \beta\gamma,\; \gamma = 0.5772 \\ Var[X] = \cfrac{\pi^2}{6}\beta^2 \end{array}$
-* - Lognormal
-  - $f(x) = \cfrac{1}{x \sigma \sqrt{2 \pi}}e^{\left( \normalsize-\cfrac{(ln(x)-\mu)^2}{2\sigma^2}\right)}$
-  - $
-F(x) = \Phi\left( \cfrac{ln(x)-\mu}{\sigma} \right) = \frac{1}{2}\left[ 1+\text{erf}\left( \cfrac{ln(x)-\mu}{\sigma \sqrt{2}}\right)\right]
-$
-  - $\begin{array}{ll} E[X]=e^{\normalsize\mu + \frac{\sigma^2}{2}} \\ Var[X] = \left( e^{\normalsize\sigma^2}-1 \right)e^{2\mu + \sigma^2} \end{array}$
-
-```
-
 % START-CREDIT
 % source: distributions
 ```{attributiongrey} Attribution

--- a/book/univariate_distributions/summary.md
+++ b/book/univariate_distributions/summary.md
@@ -3,6 +3,66 @@
 
 Here a summary of the main equations for each of the presented distirbution functions is presented.
 
+## Choosing a distribution
+
+If you need help to choose a distribution type for your data, the table below may help you make a choice:
+
+<table>
+  <thead>
+    <tr><th>Task</th><th>Status</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Build</td>
+      <td style="background:#dfd;">✅ Green (OK)</td>
+    </tr>
+    <tr>
+      <td>Tests</td>
+      <td style="background:#ffe8a1;">⚠️ Orange (Warn)</td>
+    </tr>
+    <tr>
+      <td>Deploy</td>
+      <td style="background:#fdd;">⛔ Red (Fail)</td>
+    </tr>
+  </tbody>
+</table>
+
+
+```{list-table}
+:header-rows: 1
+
+* - Distribution
+  - Uniform
+  - CDF
+  - Mean and variance
+* - Bounded left
+  - left and right
+  - $F(x) = \cfrac{1}{2}\left(1+\text{erf}\left(\cfrac{x-\mu}{\sigma\sqrt{2}}\right)\right)$
+  - $\begin{array}{ll} E[X] = \mu \\ Var[X] = \sigma^2  \end{array}$
+* - Bounded right
+  - left and right
+  - $F(x) = \cfrac{1}{2}\left(1+\text{erf}\left(\cfrac{x-\mu}{\sigma\sqrt{2}}\right)\right)$
+  - $\begin{array}{ll} E[X] = \mu \\ Var[X] = \sigma^2  \end{array}$
+* - Left-tailed
+  - yes
+  - $F(x)=\begin{cases}0 & \text{for } x<a \\ \cfrac{x-a}{b-a} & \text{for } x\in[a,b] 1 & \text{for } x>b\end{cases}$
+  - $\begin{array}{ll} E[X]=\frac{1}{2}(a+b) \\ Var[X]=\frac{1}{12}(b-a)^2 \end{array}$ 
+* - Symmetric
+  - yes
+  - $F(x)=\begin{cases}0 & \text{for } x<a \\ \cfrac{x-a}{b-a} & \text{for } x\in[a,b] 1 & \text{for } x>b\end{cases}$
+  - $\begin{array}{ll} E[X]=\frac{1}{2}(a+b) \\ Var[X]=\frac{1}{12}(b-a)^2 \end{array}$ 
+* - Right-tailed
+  - yes
+  - $F(x)=\begin{cases}0 & \text{for } x<a \\ \cfrac{x-a}{b-a} & \text{for } x\in[a,b] 1 & \text{for } x>b\end{cases}$
+  - $\begin{array}{ll} E[X]=\frac{1}{2}(a+b) \\ Var[X]=\frac{1}{12}(b-a)^2 \end{array}$ 
+
+```
+
+
+
+
+## Statistical moments
+
 ```{list-table}
 :header-rows: 1
 

--- a/book/univariate_distributions/summary.md
+++ b/book/univariate_distributions/summary.md
@@ -14,7 +14,7 @@ If you need help to choose a distribution type for your data, the table below ma
 
 <table>
   <thead>
-    <tr><th>Distribution</th><th>left bound</th><th>right bound</th><th>left tailed</th><th>symmetric</th><th>right tailed</th><th>scipy name</th></tr>
+    <tr><th>Distribution</th><th>left bound</th><th>right bound</th><th>left-tailed</th><th>symmetric</th><th>right-tailed</th><th>scipy name</th></tr>
   </thead>
   <tbody>
     <tr>
@@ -95,6 +95,21 @@ Below, we will list the equations for the PDF, CDF, mean, and variance for the p
 * - Object 
   - Equation
 * - PDF
+  - $\displaystyle f(x) = \begin{cases}\cfrac{1}{b-a} & \text{for }x \in [a,b] \\ 0 & \text{otherwise} \end{cases}$
+* - CDF
+  - $F(x)=\begin{cases}0 & \text{for } x<a \\ \cfrac{x-a}{b-a} & \text{for } x\in[a,b] 1 & \text{for } x>b\end{cases}$
+* - Mean and variance
+  - $\begin{array}{ll} E[X]=\frac{1}{2}(a+b) \\ Var[X]=\frac{1}{12}(b-a)^2 \end{array}$ 
+```
+
+### Gaussian
+
+```{list-table}
+:header-rows: 1
+
+* - Object 
+  - Equation
+* - PDF
   - $f(x) = \cfrac{1}{\sigma \sqrt{2\pi}}e^{\left(\normalsize-\cfrac{(x-\mu)^2}{2\sigma^2}\right)}$
 * - CDF
   - $F(x) = \cfrac{1}{2}\left(1+\text{erf}\left(\cfrac{x-\mu}{\sigma\sqrt{2}}\right)\right)$
@@ -102,6 +117,65 @@ Below, we will list the equations for the PDF, CDF, mean, and variance for the p
   - $\begin{array}{ll} E[X] = \mu \\ Var[X] = \sigma^2  \end{array}$
 ```
 
+### Lognormal
+
+```{list-table}
+:header-rows: 1
+
+* - Object 
+  - Equation
+* - PDF
+  - $f(x) = \cfrac{1}{x \sigma \sqrt{2 \pi}}e^{\left( \normalsize-\cfrac{(ln(x)-\mu)^2}{2\sigma^2}\right)}$
+* - CDF
+  - $F(x) = \Phi\left( \cfrac{ln(x)-\mu}{\sigma} \right) = \frac{1}{2}\left[ 1+\text{erf}\left( \cfrac{ln(x)-\mu}{\sigma \sqrt{2}}\right)\right]$
+* - Mean and variance
+  - $\begin{array}{ll} E[X]=e^{\normalsize\mu + \frac{\sigma^2}{2}} \\ Var[X] = \left( e^{\normalsize\sigma^2}-1 \right)e^{2\mu + \sigma^2} \end{array}$
+```
+
+### Gumbel
+
+```{list-table}
+:header-rows: 1
+
+* - Object 
+  - Equation
+* - PDF
+  - $f(x) = \cfrac{1}{\beta} e^{\normalsize-\left(z + e^{\normalsize-z}\right)}\text{, where }z=\cfrac{x-\alpha}{\beta}$
+* - CDF
+  - $F(x)=e^{\normalsize-e^{\normalsize-z}}$
+* - Mean and variance
+  - $\begin{array}{ll} E[X] = \alpha + \beta\gamma,\; \gamma = 0.5772 \\ Var[X] = \cfrac{\pi^2}{6}\beta^2 \end{array}$
+```
+
+### Exponential
+
+```{list-table}
+:header-rows: 1
+
+* - Object 
+  - Equation
+* - PDF
+  - $f(x) = \lambda e^{\normalsize-\lambda x}$
+* - CDF
+  - $F(x) = 1 - e^{\normalsize-\lambda x}$
+* - Mean and variance
+  - $\begin{array}{ll} E[X] = \cfrac{1}{\lambda} \\ Var[X] = \cfrac{1}{\lambda^2} \end{array}$
+```
+
+### Beta
+
+```{list-table}
+:header-rows: 1
+
+* - Object 
+  - Equation
+* - PDF
+  - $f(x) = \frac{x^{\alpha - 1} (1 - x)^{\beta - 1}}{B(\alpha, \beta)}$
+* - CDF
+  - $F(x; \alpha, \beta) = \frac{1}{B(\alpha, \beta)} \int_0^x t^{\alpha - 1} (1 - t)^{\beta - 1} dt$
+* - Mean and variance
+  - $\begin{array}{ll} E[X] = \frac{\alpha}{\alpha + \beta} \\ Var[X] = \frac{\alpha\beta}{(\alpha + \beta)^2(\alpha+\beta+1)}  \end{array}$
+```
 
 
 ```{list-table}

--- a/book/univariate_distributions/summary.md
+++ b/book/univariate_distributions/summary.md
@@ -89,17 +89,20 @@ Below, we will list the equations for the PDF, CDF, mean, and variance for the p
 
 ### Uniform
 
-#### PDF
-$\displaystyle f(x) = \begin{cases}\cfrac{1}{b-a} & \text{for }x \in [a,b] \\ 0 & \text{otherwise} \end{cases}$
+```{list-table}
+:header-rows: 1
 
-#### CDF
-$F(x)=\begin{cases}0 & \text{for } x<a \\ \cfrac{x-a}{b-a} & \text{for } x\in[a,b] 1 & \text{for } x>b\end{cases}$
+* - Object 
+  - Equation
+* - PDF
+  - $f(x) = \cfrac{1}{\sigma \sqrt{2\pi}}e^{\left(\normalsize-\cfrac{(x-\mu)^2}{2\sigma^2}\right)}$
+* - CDF
+  - $F(x) = \cfrac{1}{2}\left(1+\text{erf}\left(\cfrac{x-\mu}{\sigma\sqrt{2}}\right)\right)$
+* - Mean and variance
+  - $\begin{array}{ll} E[X] = \mu \\ Var[X] = \sigma^2  \end{array}$
+```
 
-#### Mean and variance
-$\begin{array}{ll} E[X]=\frac{1}{2}(a+b) \\ Var[X]=\frac{1}{12}(b-a)^2 \end{array}$
 
-### Gaussian
-blorb
 
 ```{list-table}
 :header-rows: 1

--- a/book/univariate_distributions/summary.md
+++ b/book/univariate_distributions/summary.md
@@ -83,9 +83,30 @@ If you need help to choose a distribution type for your data, the table below ma
   </tbody>
 </table>
 
+```{admonition} Notation
+:class: tip
+
+One challenge when dealing with distributions is notation, for two main reasons: 1) the symbols used to represent random variables and parameters vary across different fields (and even _within_ a given field); and 2) the formulation of key equations (i.e., the PDF and CDF) can vary depending on the parameterization used.
+
+Why such variation? Let's just say tradition, history and stubbornness play a big role here. But more importantly, one should recognize that the equations or parameters often have physical meaning, which makes a certain formulation more logical. Symbols often must be choseon not to conflict with others used in a given field.
+
+To illustrate the point, consider the following three formulations of the PDF of the exponential distribution (along with a link to the page ):
+
+- [Wikipedia](https://en.wikipedia.org/wiki/Exponential_distribution), [Excel](https://support.microsoft.com/en-us/office/expon-dist-function-4c12ae24-e563-4155-bf3e-8b78b6ae140e): $f(x) = \lambda exp(-\lambda x)$
+- [Matlab](https://www.mathworks.com/help/stats/exponential-distribution.html):  $f(x) = \frac{1}{\mu} exp(\frac{-x}{\mu}
+- [Scipy Stats Module](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.expon.html#scipy.stats.expon):  $f(x) = exp(- x)$
+
+Note that the formulation is very different between each case, and either $\lambda$ or $\mu$ is used. If you are not careful when using distributions from different textbooks or software packages, it is very easy to make mistakes! The scipy stats formulation is especially striking; you will learn more about this later (location, shape and scale).
+
+Our advice: **always check the formulation of the PDF, CDF and parameters of a distribution and be sure to use it consistently.**
+
+In this case, "consistency" can mean, for example, using the right equations to compute the distribution parameters from the moments (mean and standard deviation) of the distribution. In general, there is no "correct" formulation or set of parameters; in this book we present a set of parameters and formulations that are consistent with each other and commonly used in civil engineering and geosciences.
+```
+
 ## Statistical moments
 
 Below, we will list the equations for the PDF, CDF, mean, and variance for the parametric distributions we have discussed.
+
 
 #### Uniform
 

--- a/book/univariate_distributions/summary.md
+++ b/book/univariate_distributions/summary.md
@@ -87,7 +87,7 @@ If you need help to choose a distribution type for your data, the table below ma
 
 Below, we will list the equations for the PDF, CDF, mean, and variance for the parametric distributions we have discussed.
 
-### Uniform
+#### Uniform
 
 ```{list-table}
 :header-rows: 1
@@ -102,7 +102,7 @@ Below, we will list the equations for the PDF, CDF, mean, and variance for the p
   - $\begin{array}{ll} E[X]=\frac{1}{2}(a+b) \\ Var[X]=\frac{1}{12}(b-a)^2 \end{array}$ 
 ```
 
-### Gaussian
+#### Gaussian
 
 ```{list-table}
 :header-rows: 1
@@ -117,7 +117,7 @@ Below, we will list the equations for the PDF, CDF, mean, and variance for the p
   - $\begin{array}{ll} E[X] = \mu \\ Var[X] = \sigma^2  \end{array}$
 ```
 
-### Lognormal
+#### Lognormal
 
 ```{list-table}
 :header-rows: 1
@@ -132,7 +132,7 @@ Below, we will list the equations for the PDF, CDF, mean, and variance for the p
   - $\begin{array}{ll} E[X]=e^{\normalsize\mu + \frac{\sigma^2}{2}} \\ Var[X] = \left( e^{\normalsize\sigma^2}-1 \right)e^{2\mu + \sigma^2} \end{array}$
 ```
 
-### Gumbel
+#### Gumbel
 
 ```{list-table}
 :header-rows: 1
@@ -147,7 +147,7 @@ Below, we will list the equations for the PDF, CDF, mean, and variance for the p
   - $\begin{array}{ll} E[X] = \alpha + \beta\gamma,\; \gamma = 0.5772 \\ Var[X] = \cfrac{\pi^2}{6}\beta^2 \end{array}$
 ```
 
-### Exponential
+#### Exponential
 
 ```{list-table}
 :header-rows: 1
@@ -162,7 +162,7 @@ Below, we will list the equations for the PDF, CDF, mean, and variance for the p
   - $\begin{array}{ll} E[X] = \cfrac{1}{\lambda} \\ Var[X] = \cfrac{1}{\lambda^2} \end{array}$
 ```
 
-### Beta
+#### Beta
 
 ```{list-table}
 :header-rows: 1

--- a/book/univariate_distributions/summary.md
+++ b/book/univariate_distributions/summary.md
@@ -88,7 +88,7 @@ If you need help to choose a distribution type for your data, the table below ma
 
 One challenge when dealing with distributions is notation, for two main reasons: 1) the symbols used to represent random variables and parameters vary across different fields (and even _within_ a given field); and 2) the formulation of key equations (i.e., the PDF and CDF) can vary depending on the parameterization used.
 
-Why such variation? Let's just say tradition, history and stubbornness play a big role here. But more importantly, one should recognize that the equations or parameters often have physical meaning, which makes a certain formulation more logical. Symbols often must be choseon not to conflict with others used in a given field.
+Why such variation? Let's just say tradition, history, and stubbornness play a big role here. But more importantly, one should recognize that the equations or parameters often have physical meaning, which makes a certain formulation more logical. Symbols often must be chosen carefully to not conflict with others used in a given field.
 
 To illustrate the point, consider the following three formulations of the PDF of the exponential distribution (along with a link to the page ):
 
@@ -98,7 +98,7 @@ To illustrate the point, consider the following three formulations of the PDF of
 
 Note that the formulation is very different between each case, and either $\lambda$ or $\mu$ is used. If you are not careful when using distributions from different textbooks or software packages, it is very easy to make mistakes! The scipy stats formulation is especially striking; you will learn more about this later (location, shape and scale).
 
-Our advice: **always check the formulation of the PDF, CDF and parameters of a distribution and be sure to use them consistently.**
+Our advice: **always check the formulation of the PDF, CDF, and parameters of a distribution and be sure to use them consistently.**
 
 In this case, "consistency" can mean, for example, using the right equations to compute the distribution parameters from the moments (mean and standard deviation) of the distribution. In general, there is no "correct" formulation or set of parameters; in this book we present a set of parameters and formulations that are consistent with each other and commonly used in civil engineering and geosciences.
 ```

--- a/book/univariate_distributions/summary.md
+++ b/book/univariate_distributions/summary.md
@@ -3,6 +3,11 @@
 
 Here a summary of the main equations for each of the presented distirbution functions is presented.
 
+```{admonition} MUDE exam information
+:class: tip, dropdown
+You do not need to know the equations of the distribution functions by heart. You just need to know how the distribution looks (PDF/CDF), how it responds to changes in the parameters, and some of its basic properties (particularly symmetry or bounds).
+```
+
 ## Choosing a distribution
 
 If you need help to choose a distribution type for your data, the table below may help you make a choice:
@@ -80,6 +85,22 @@ If you need help to choose a distribution type for your data, the table below ma
 
 ## Statistical moments
 
+Below, we will list the equations for the PDF, CDF, mean, and variance for the parametric distributions we have discussed.
+
+### Uniform
+
+#### PDF
+$\displaystyle f(x) = \begin{cases}\cfrac{1}{b-a} & \text{for }x \in [a,b] \\ 0 & \text{otherwise} \end{cases}$
+
+#### CDF
+$F(x)=\begin{cases}0 & \text{for } x<a \\ \cfrac{x-a}{b-a} & \text{for } x\in[a,b] 1 & \text{for } x>b\end{cases}$
+
+#### Mean and variance
+$\begin{array}{ll} E[X]=\frac{1}{2}(a+b) \\ Var[X]=\frac{1}{12}(b-a)^2 \end{array}$
+
+### Gaussian
+blorb
+
 ```{list-table}
 :header-rows: 1
 
@@ -114,11 +135,6 @@ F(x) = \Phi\left( \cfrac{ln(x)-\mu}{\sigma} \right) = \frac{1}{2}\left[ 1+\text{
 $
   - $\begin{array}{ll} E[X]=e^{\normalsize\mu + \frac{\sigma^2}{2}} \\ Var[X] = \left( e^{\normalsize\sigma^2}-1 \right)e^{2\mu + \sigma^2} \end{array}$
 
-```
-
-```{admonition} MUDE exam information
-:class: tip, dropdown
-You do not need to know the equations of the distribution functions by heart. You just need to know how the distribution looks (PDF/CDF), how it responds to changes in the parameters, and some of its basic properties (particularly symmetry or bounds).
 ```
 
 % START-CREDIT

--- a/book/univariate_distributions/summary.md
+++ b/book/univariate_distributions/summary.md
@@ -19,7 +19,7 @@ If you need help to choose a distribution type for your data, the table below ma
       <td style="background:#fdd;">no</td>
       <td style="background:#dfd;">yes</td>
       <td style="background:#fdd;">no</td>
-      <td>`uniform`</td>
+      <td>uniform</td>
     </tr>
     <tr>
       <td>Gaussian</td>
@@ -28,7 +28,7 @@ If you need help to choose a distribution type for your data, the table below ma
       <td style="background:#fdd;">no</td>
       <td style="background:#dfd;">yes</td>
       <td style="background:#fdd;">no</td>
-      <td>`norm`</td>
+      <td>norm</td>
     </tr>
     <tr>
       <td>Lognormal</td>
@@ -37,16 +37,25 @@ If you need help to choose a distribution type for your data, the table below ma
       <td style="background:#fdd;">no</td>
       <td style="background:#fdd;">no</td>
       <td style="background:#dfd;">yes</td>
-      <td>`lognorm`</td>
+      <td>lognorm</td>
     </tr>
     <tr>
-      <td>Gumbel</td>
+      <td>Gumbel (right-tailed)</td>
       <td style="background:#fdd;">no</td>
       <td style="background:#fdd;">no</td>
-      <td style="background:#ffe8a1;">possible</td>
       <td style="background:#fdd;">no</td>
-      <td style="background:#ffe8a1;">possible</td>
-      <td>`gumbel_r` / `gumbel_l`</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#dfd;">yes</td>
+      <td>gumbel_r</td>
+    </tr>
+    <tr>
+      <td>Gumbel (left-tailed)</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#dfd;">yes</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#fdd;">no</td>
+      <td>gumbel_l</td>
     </tr>
     <tr>
       <td>exponential</td>
@@ -55,7 +64,7 @@ If you need help to choose a distribution type for your data, the table below ma
       <td style="background:#fdd;">no</td>
       <td style="background:#fdd;">no</td>
       <td style="background:#dfd;">yes</td>
-      <td>`expon`</td>
+      <td>expon</td>
     </tr>
     <tr>
       <td>beta</td>
@@ -64,45 +73,10 @@ If you need help to choose a distribution type for your data, the table below ma
       <td style="background:#ffe8a1;">possible</td>
       <td style="background:#ffe8a1;">possible</td>
       <td style="background:#ffe8a1;">possible</td>
-      <td>`beta`</td>
+      <td>beta</td>
     </tr>
-
   </tbody>
 </table>
-
-
-```{list-table}
-:header-rows: 1
-
-* - Distribution
-  - Uniform
-  - CDF
-  - Mean and variance
-* - Bounded left
-  - left and right
-  - $F(x) = \cfrac{1}{2}\left(1+\text{erf}\left(\cfrac{x-\mu}{\sigma\sqrt{2}}\right)\right)$
-  - $\begin{array}{ll} E[X] = \mu \\ Var[X] = \sigma^2  \end{array}$
-* - Bounded right
-  - left and right
-  - $F(x) = \cfrac{1}{2}\left(1+\text{erf}\left(\cfrac{x-\mu}{\sigma\sqrt{2}}\right)\right)$
-  - $\begin{array}{ll} E[X] = \mu \\ Var[X] = \sigma^2  \end{array}$
-* - Left-tailed
-  - yes
-  - $F(x)=\begin{cases}0 & \text{for } x<a \\ \cfrac{x-a}{b-a} & \text{for } x\in[a,b] 1 & \text{for } x>b\end{cases}$
-  - $\begin{array}{ll} E[X]=\frac{1}{2}(a+b) \\ Var[X]=\frac{1}{12}(b-a)^2 \end{array}$ 
-* - Symmetric
-  - yes
-  - $F(x)=\begin{cases}0 & \text{for } x<a \\ \cfrac{x-a}{b-a} & \text{for } x\in[a,b] 1 & \text{for } x>b\end{cases}$
-  - $\begin{array}{ll} E[X]=\frac{1}{2}(a+b) \\ Var[X]=\frac{1}{12}(b-a)^2 \end{array}$ 
-* - Right-tailed
-  - yes
-  - $F(x)=\begin{cases}0 & \text{for } x<a \\ \cfrac{x-a}{b-a} & \text{for } x\in[a,b] 1 & \text{for } x>b\end{cases}$
-  - $\begin{array}{ll} E[X]=\frac{1}{2}(a+b) \\ Var[X]=\frac{1}{12}(b-a)^2 \end{array}$ 
-
-```
-
-
-
 
 ## Statistical moments
 

--- a/book/univariate_distributions/summary.md
+++ b/book/univariate_distributions/summary.md
@@ -93,12 +93,12 @@ Why such variation? Let's just say tradition, history and stubbornness play a bi
 To illustrate the point, consider the following three formulations of the PDF of the exponential distribution (along with a link to the page ):
 
 - [Wikipedia](https://en.wikipedia.org/wiki/Exponential_distribution), [Excel](https://support.microsoft.com/en-us/office/expon-dist-function-4c12ae24-e563-4155-bf3e-8b78b6ae140e): $f(x) = \lambda exp(-\lambda x)$
-- [Matlab](https://www.mathworks.com/help/stats/exponential-distribution.html):  $f(x) = \frac{1}{\mu} exp(\frac{-x}{\mu}
+- [Matlab](https://www.mathworks.com/help/stats/exponential-distribution.html):  $f(x) = \frac{1}{\mu} exp(\frac{-x}{\mu}$
 - [Scipy Stats Module](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.expon.html#scipy.stats.expon):  $f(x) = exp(- x)$
 
 Note that the formulation is very different between each case, and either $\lambda$ or $\mu$ is used. If you are not careful when using distributions from different textbooks or software packages, it is very easy to make mistakes! The scipy stats formulation is especially striking; you will learn more about this later (location, shape and scale).
 
-Our advice: **always check the formulation of the PDF, CDF and parameters of a distribution and be sure to use it consistently.**
+Our advice: **always check the formulation of the PDF, CDF and parameters of a distribution and be sure to use them consistently.**
 
 In this case, "consistency" can mean, for example, using the right equations to compute the distribution parameters from the moments (mean and standard deviation) of the distribution. In general, there is no "correct" formulation or set of parameters; in this book we present a set of parameters and formulations that are consistent with each other and commonly used in civil engineering and geosciences.
 ```

--- a/book/univariate_distributions/summary.md
+++ b/book/univariate_distributions/summary.md
@@ -172,7 +172,7 @@ Below, we will list the equations for the PDF, CDF, mean, and variance for the p
 * - PDF
   - $f(x) = \frac{x^{\alpha - 1} (1 - x)^{\beta - 1}}{B(\alpha, \beta)}$
 * - CDF
-  - $F(x; \alpha, \beta) = \frac{1}{B(\alpha, \beta)} \int_0^x t^{\alpha - 1} (1 - t)^{\beta - 1} dt$
+  - $F(x) = \frac{1}{B(\alpha, \beta)} \int_0^x t^{\alpha - 1} (1 - t)^{\beta - 1} dt$
 * - Mean and variance
   - $\begin{array}{ll} E[X] = \frac{\alpha}{\alpha + \beta} \\ Var[X] = \frac{\alpha\beta}{(\alpha + \beta)^2(\alpha+\beta+1)}  \end{array}$
 ```

--- a/book/univariate_distributions/summary.md
+++ b/book/univariate_distributions/summary.md
@@ -9,21 +9,64 @@ If you need help to choose a distribution type for your data, the table below ma
 
 <table>
   <thead>
-    <tr><th>Task</th><th>Status</th></tr>
+    <tr><th>Distribution</th><th>left bound</th><th>right bound</th><th>left tailed</th><th>symmetric</th><th>right tailed</th><th>scipy name</th></tr>
   </thead>
   <tbody>
     <tr>
-      <td>Build</td>
-      <td style="background:#dfd;">✅ Green (OK)</td>
+      <td>Uniform</td>
+      <td style="background:#dfd;">yes</td>
+      <td style="background:#dfd;">yes</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#dfd;">yes</td>
+      <td style="background:#fdd;">no</td>
+      <td>`uniform`</td>
     </tr>
     <tr>
-      <td>Tests</td>
-      <td style="background:#ffe8a1;">⚠️ Orange (Warn)</td>
+      <td>Gaussian</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#dfd;">yes</td>
+      <td style="background:#fdd;">no</td>
+      <td>`norm`</td>
     </tr>
     <tr>
-      <td>Deploy</td>
-      <td style="background:#fdd;">⛔ Red (Fail)</td>
+      <td>Lognormal</td>
+      <td style="background:#dfd;">yes</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#dfd;">yes</td>
+      <td>`lognorm`</td>
     </tr>
+    <tr>
+      <td>Gumbel</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#ffe8a1;">possible</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#ffe8a1;">possible</td>
+      <td>`gumbel_r` / `gumbel_l`</td>
+    </tr>
+    <tr>
+      <td>exponential</td>
+      <td style="background:#dfd;">yes</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#fdd;">no</td>
+      <td style="background:#dfd;">yes</td>
+      <td>`expon`</td>
+    </tr>
+    <tr>
+      <td>beta</td>
+      <td style="background:#dfd;">yes</td>
+      <td style="background:#dfd;">yes</td>
+      <td style="background:#ffe8a1;">possible</td>
+      <td style="background:#ffe8a1;">possible</td>
+      <td style="background:#ffe8a1;">possible</td>
+      <td>`beta`</td>
+    </tr>
+
   </tbody>
 </table>
 


### PR DESCRIPTION
The current [summary page for the parametric distributions](https://mude.citg.tudelft.nl/book/updating-week-1.4/univariate_distributions/summary.html) includes a large table that requires scrolling to reveal the column for the mean and variance. Robert proposed updating it.

In this branch, I have updated the summary page to now:
- include a table that showcases some of the features of each distribution (bounds, symmetry)
- breaks up the table into smaller tables for each distribution that can be read without requiring horizontal scrolling

You can check out the proposed summary page [here](https://mude.citg.tudelft.nl/book/updating-week-1.4-edits-to-summary-page/univariate_distributions/summary.html).