### PR TITLE
small error in 9-boundary-value-problem.ipynb 

### DIFF
--- a/book/numerical_methods/9-boundary-value-problem.ipynb
+++ b/book/numerical_methods/9-boundary-value-problem.ipynb
@@ -447,7 +447,7 @@
     "$$\n",
     "\n",
     "$$\n",
-    "\\text{Forward Difference: } f'= \\frac{f(x_{i+1})-f(x_1)}{\\Delta x}+ \\mathcal{O}(\\Delta x)\n",
+    "\\text{Forward Difference: } f'= \\frac{f(x_{i+1})-f(x_i)}{\\Delta x}+ \\mathcal{O}(\\Delta x)\n",
     "$$\n",
     "\n",
     "$$\n",


### PR DESCRIPTION
fixed simple issue with forward difference at summary: f(x_1) should be f(x_i)

nitpicking at this point, but since you ABSOLUTELY should use this book again might as well change it.