### PR TITLE
Remove week 2 programming section from TOC

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -292,7 +292,6 @@ parts:
       - external: https://github.com/TeachBooks/learn-programming/blob/mude-2025/book/llms/generating-code.ipynb
       - external: https://github.com/TeachBooks/learn-programming/blob/mude-2025/book/llms/debugging-errors.ipynb
       - external: https://github.com/TeachBooks/learn-programming/blob/mude-2025/book/llms/human-in-the-loop.ipynb
-# START REMOVE-FROM-PUBLISH
     - file: programming/week_2_1
       sections:
       - external: https://github.com/TeachBooks/learn-programming/blob/mude-2025/book/python/oop/intro.md
@@ -301,6 +300,7 @@ parts:
       - external: https://github.com/TeachBooks/learn-programming/blob/mude-2025/book/python/oop/Inheritance.ipynb
       - external: https://github.com/TeachBooks/learn-programming/blob/mude-2025/book/python/oop/Polymorphism.ipynb
       - external: https://github.com/TeachBooks/learn-programming/blob/mude-2025/book/python/oop/exercise.ipynb
+# START REMOVE-FROM-PUBLISH
     - file: programming/week_1_6_old
       sections:
       - file: external/learn-python/book/09/intro.md


### PR DESCRIPTION
Removed section related to week 2 programming content from the table of contents.