### PR TITLE
changed default distribution to Gamma

### DIFF
--- a/book/_static/elements/element_failure_rate.html
+++ b/book/_static/elements/element_failure_rate.html
@@ -116,7 +116,7 @@
       // Parameters for failure distributions
       var Alpha  = 1.5;             // alpha > 0 (shape)
       var Lambda = 1.0;             // lambda > 0 (rate/scale)
-      var Dist   = 'exponential';   // 'exponential', 'gamma', 'weibull'
+      var Dist   = 'gamma';         // 'exponential', 'gamma', 'weibull'
 
       function linspace(start, end, resolution) {
         var spacing = [];


### PR DESCRIPTION
Just a small fix that changed the default distribution of the risk and reliability risk curve interactive element from epxonential to gamma