### PR TITLE
Enhance GNSS model to estimate clock error

### DIFF
--- a/book/observation_theory/01_Introduction.md
+++ b/book/observation_theory/01_Introduction.md
@@ -132,7 +132,7 @@ $$
 
 (positioning)=
 #### GNSS Positioning 
-As a final example we will consider a non-linear functional model for estimating the unknown position $\mathrm{x}=\begin{bmatrix} x, y, z\end{bmatrix}^T$ of a Global Navigation Satellite System (GNSS) receiver on Earth. The observables are distance measured for $m \geq 4$ GNSS satellites with known positions $\begin{bmatrix} x_i, y_i, z_i\end{bmatrix}^T$.
+As a final example we will consider a non-linear functional model for estimating the unknown position and clock error $\mathrm{x}=\begin{bmatrix} x, y, z, b\end{bmatrix}^T$ of a Global Navigation Satellite System (GNSS) receiver on Earth. The observables are distances (pseudoranges) measured for $m \geq 4$ GNSS satellites with known positions $\begin{bmatrix} x_i, y_i, z_i\end{bmatrix}^T$.
 
 ```{figure} https://upload.wikimedia.org/wikipedia/commons/9/91/GDOP_good.svg
 ---
@@ -145,11 +145,11 @@ GNSS positioning: the position of the user is estimated from four GNSS satellite
 The functional model comprises $m$ non-linear functions of the unknown parameter vector $\mathrm{x}$:
 
 $$
-\mathbb{E}(\begin{bmatrix} Y_{1} \\ Y_{2} \\ \vdots \\ Y_{m} \end{bmatrix} )= \begin{bmatrix} \sqrt{(x_1-x)^2+(y_1-y)^2+(z_1-z)^2}\\ \sqrt{(x_2-x)^2+(y_2-y)^2+(z_2-z)^2} \\ \vdots \\ \sqrt{(x_m-x)^2+(y_m-y)^2+(z_m-z)^2}\end{bmatrix}
-=\begin{bmatrix} q_{1}(\mathrm{x}) \\ q_{2}(\mathrm{x}) \\ \vdots \\ q_{m}(\mathrm{x}) \end{bmatrix}
+\mathbb{E}(\begin{bmatrix} Y_{1} \\ Y_{2} \\ \vdots \\ Y_{m} \end{bmatrix} )= \begin{bmatrix} \sqrt{(x_1-x)^2+(y_1-y)^2+(z_1-z)^2}+b\\ \sqrt{(x_2-x)^2+(y_2-y)^2+(z_2-z)^2} +b\\ \vdots \\ \sqrt{(x_m-x)^2+(y_m-y)^2+(z_m-z)^2}\end{bmatrix}
+=\begin{bmatrix} q_{1}(\mathrm{x}) \\ q_{2}(\mathrm{x}) +b\\ \vdots \\ q_{m}(\mathrm{x}) \end{bmatrix}
 $$
 
-Where $Y_i$ is the distance measurement to satellite $i$. Note that the functional model is non-linear in $\mathrm{x}$, since the unknown parameters appear inside a square root.
+Where $Y_i$ is the distance measurement to satellite $i$. Note that the functional model is non-linear in $\mathrm{x}$, since three of the unknown parameters appear inside a square root.
 
 ## Redundancy
 Later we will see that the *redundancy* of our model plays an important role regarding the precision of our estimated parameters. For a model with $m$ observables and $n$ unknown parameters, the redundancy is given by:


### PR DESCRIPTION
Updated the GNSS positioning model to include clock error in the parameter vector and adjusted the equations accordingly.